### PR TITLE
Hotfix for Export Measurements Exception + Client Configuration user_id Exception

### DIFF
--- a/server/app/controllers/measurements_controller.rb
+++ b/server/app/controllers/measurements_controller.rb
@@ -2,7 +2,7 @@ class MeasurementsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @measurements = current_user.measurements
+    @measurements = policy_scope(Measurement)
     authorize @measurements
     respond_to do |format|
       format.csv { send_data @measurements.to_csv, filename: "measurements.csv" }

--- a/server/app/policies/measurement_policy.rb
+++ b/server/app/policies/measurement_policy.rb
@@ -1,24 +1,21 @@
 # Headless policy
 # https://www.rubydoc.info/gems/pundit#:~:text=edit_post_path(%40post)%20%25%3E%0A%3C%25%20end%20%25%3E-,Headless%20policies,-Given%20there%20is
-class MeasurementPolicy
+class MeasurementPolicy < ApplicationPolicy
 
   # TODO: move ALL current roles such as exportuser
   # into account level. Opening a ticket for it. For
   # now, will leave at user level for everything to
   # work as before.
-  def initialize(user_account, _record)
-    @user = User.find(user_account.user_id)
-  end
 
   def index?
     true
   end
 
   def full_index?
-    @user.superuser || @user.exportuser
+    @user_account.user.superuser || @user_account.user.exportuser
   end
 
   def full_ndt7_index?
-    @user.superuser || @user.exportuser
+    @user_account.user.superuser || @user_account.user.exportuser
   end
 end

--- a/server/app/views/clients/configuration.json.jbuilder
+++ b/server/app/views/clients/configuration.json.jbuilder
@@ -1,3 +1,3 @@
-json.extract! @client, :id, :unix_user, :name, :address, :public_key, :endpoint_host, :endpoint_port, :remote_gateway_port, :user_id, :created_at, :updated_at
+json.extract! @client, :id, :unix_user, :name, :address, :public_key, :endpoint_host, :endpoint_port, :remote_gateway_port, :created_at, :updated_at
 json.private_key @private_key
 json.url client_url(@client.unix_user, format: :json)


### PR DESCRIPTION
This PR includes the following issues:
TTAC-364: [Radar] Export data throws exception when clicking "Export Measurements"

>> Specific exceptions handled:
https://sentry.io/organizations/exactly-labs/issues/3470038367/?project=6320151&query=is%3Aunresolved
https://sentry.io/organizations/exactly-labs/issues/3476704936/?query=&statsPeriod=14d