### PR TITLE
Multiple UX changes

### DIFF
--- a/server/app/javascript/controllers/add_account_controller.js
+++ b/server/app/javascript/controllers/add_account_controller.js
@@ -32,35 +32,23 @@ export default class extends Controller {
   selectPersonal() {
     const classList = this.personalBoxTarget.classList;
     const otherClassList = this.organizationBoxTarget.classList;
-    if (classList.contains("selected")) {
-      classList.remove("selected");
-      this.continueToNameButtonTarget.classList.add("disabled");
-      this.selectType(null);
-    } else {
-      if (otherClassList.contains("selected")) {
-        otherClassList.remove("selected");
-      }
-      classList.add("selected");
-      this.continueToNameButtonTarget.classList.remove("disabled");
-      this.selectType("personal");
+    if (otherClassList.contains("selected")) {
+      otherClassList.remove("selected");
     }
+    classList.add("selected");
+    this.continueToNameButtonTarget.classList.remove("disabled");
+    this.selectType("personal");
   }
 
   selectOrganization() {
     const classList = this.organizationBoxTarget.classList;
     const otherClassList = this.personalBoxTarget.classList;
-    if (classList.contains("selected")) {
-      classList.remove("selected");
-      this.continueToNameButtonTarget.classList.add("disabled");
-      this.selectType(null);
-    } else {
-      if (otherClassList.contains("selected")) {
-        otherClassList.remove("selected");
-      }
-      classList.add("selected");
-      this.continueToNameButtonTarget.classList.remove("disabled");
-      this.selectType("organization");
+    if (otherClassList.contains("selected")) {
+      otherClassList.remove("selected");
     }
+    classList.add("selected");
+    this.continueToNameButtonTarget.classList.remove("disabled");
+    this.selectType("organization");
   }
 
   selectType(type) {
@@ -84,6 +72,7 @@ export default class extends Controller {
     this.step1Target.style.display = "flex";
     this.step0FooterTarget.style.display = "none";
     this.step1FooterTarget.style.display = "flex";
+    this.accountNameInputTarget.focus();
     this.clearAccountName();
     if (type === "personal") {
       this.accountNameLabelTarget.innerText = "Name";

--- a/server/app/javascript/controllers/registration_controller.js
+++ b/server/app/javascript/controllers/registration_controller.js
@@ -210,35 +210,23 @@ export default class extends Controller {
   selectPersonal() {
     const classList = this.personalBoxTarget.classList;
     const otherClassList = this.organizationBoxTarget.classList;
-    if (classList.contains("selected")) {
-      classList.remove("selected");
-      this.continueToNameButtonTarget.classList.add("disabled");
-      this.selectType(null);
-    } else {
-      if (otherClassList.contains("selected")) {
-        otherClassList.remove("selected");
-      }
-      classList.add("selected");
-      this.continueToNameButtonTarget.classList.remove("disabled");
-      this.selectType("personal");
+    if (otherClassList.contains("selected")) {
+      otherClassList.remove("selected");
     }
+    classList.add("selected");
+    this.continueToNameButtonTarget.classList.remove("disabled");
+    this.selectType("personal");
   }
 
   selectOrganization() {
     const classList = this.organizationBoxTarget.classList;
     const otherClassList = this.personalBoxTarget.classList;
-    if (classList.contains("selected")) {
-      classList.remove("selected");
-      this.continueToNameButtonTarget.classList.add("disabled");
-      this.selectType(null);
-    } else {
-      if (otherClassList.contains("selected")) {
-        otherClassList.remove("selected");
-      }
-      classList.add("selected");
-      this.continueToNameButtonTarget.classList.remove("disabled");
-      this.selectType("organization");
+    if (otherClassList.contains("selected")) {
+      otherClassList.remove("selected");
     }
+    classList.add("selected");
+    this.continueToNameButtonTarget.classList.remove("disabled");
+    this.selectType("organization");
   }
 
   clearTypes() {
@@ -266,6 +254,7 @@ export default class extends Controller {
     this.step2WrapperTarget.style.display = "none";
     this.step3WrapperTarget.style.display = "flex";
     this.clearAccountName();
+    this.accountNameInputTarget.focus();
     if (type === "personal") {
       this.accountNameLabelTarget.innerText = "Name";
       this.accountNameInputTarget.placeholder = "E.g.: John's Home";

--- a/server/app/javascript/controllers/switch_account_controller.js
+++ b/server/app/javascript/controllers/switch_account_controller.js
@@ -20,19 +20,22 @@ export default class extends Controller {
         currentAccount = cookie.split("=")[1];
       }
     });
-    if (currentAccount && currentAccount === selectedAccountId) return;
-    const token = document.getElementsByName("csrf-token")[0].content;
-    fetch(`/accounts/switch?id=${selectedAccountId}`, {
-      method: "POST",
-      headers: { "X-CSRF-Token": token },
-    }).then((res) => {
-      if (res.ok) {
-        window.location.reload();
-      } else {
-        // TODO: add Sentry logging once integrated
-        console.error(res);
-      }
-    });
+    if (currentAccount && currentAccount === selectedAccountId) {
+      window.location.href = "/dashboard";
+    } else {
+      const token = document.getElementsByName("csrf-token")[0].content;
+      fetch(`/accounts/switch?id=${selectedAccountId}`, {
+        method: "POST",
+        headers: { "X-CSRF-Token": token },
+      }).then((res) => {
+        if (res.ok) {
+          window.location.reload();
+        } else {
+          // TODO: add Sentry logging once integrated
+          console.error(res);
+        }
+      });
+    }
   }
 
   showMoreOptionsIcon(e) {

--- a/server/app/views/application/_location_options_card.html.erb
+++ b/server/app/views/application/_location_options_card.html.erb
@@ -14,7 +14,7 @@
               <rect id="Rectangle" x="1" y="2" width="12" height="2" rx="1" fill="black"/>
           </svg>
           </span>
-          <div class="d-md-none d-xl-block ms-3">Locations</div>
+          <div class="d-md-none d-xl-block ms-3">Overview</div>
         </a>
       </li>
       <li class="list-group-item border-0 mb-5 p-0 d-flex justify-content-start">

--- a/server/app/views/devise/sessions/invite/new.html.erb
+++ b/server/app/views/devise/sessions/invite/new.html.erb
@@ -13,7 +13,7 @@
         <!--end::Title-->
         <!--begin::Link-->
           <div class="text-gray-400 fw-bold fs-4">New Here?
-            <a href="<%= users_register_from_invite_path(id: params[:id], first_name: params[:first_name], last_name: params[:last_name], email: params[:email]) %>" class="link-primary fw-bolder">Create an Account</a>
+            <a href="<%= users_invite_sign_up_path(token: params[:token]) %>" class="link-primary fw-bolder">Create an Account</a>
           </div>
         <!--end::Link-->
       </div>

--- a/server/app/views/users/_users_table.html.erb
+++ b/server/app/views/users/_users_table.html.erb
@@ -3,9 +3,8 @@
   <div class="card-body pt-0 px-0">
     <!--begin::Table-->
     <div id="kt_customers_table_wrapper" class="dataTables_wrapper dt-bootstrap4 no-footer">
-      <div class="table-responsive">
-        <table class="table table-row-bordered align-middle fs-6 gy-5 dataTable
-                          no-footer table-rounded" id="kt_customers_table">
+      <div class="table-responsive" style="overflow: visible">
+        <table class="table table-row-bordered align-middle fs-6 gy-5 dataTable no-footer table-rounded" id="kt_customers_table">
           <!--begin::Table head-->
           <thead>
           <!--begin::Table row-->
@@ -29,12 +28,12 @@
           <!--end::Table head-->
           <!--begin::Table body-->
           <tbody class="fw-bold text-gray-600" id="users_table">
-          <% users_accounts.each_with_index do |user_account, index| %>
-            <%= render partial: "users/users_table_row_user_account", locals: { user_account: user_account, is_even: index % 2 == 0 } %>
-          <% end %>
-          <% invited_users.each_with_index do |invitee, index| %>
-            <%= render partial: "users/users_table_row_invitee", locals: { invitee: invitee, is_even: (index + users_accounts.length) % 2 == 0 } %>
-          <% end %>
+            <% users_accounts.each_with_index do |user_account, index| %>
+              <%= render partial: "users/users_table_row_user_account", locals: { user_account: user_account, is_even: index % 2 == 0 } %>
+            <% end %>
+            <% invited_users.each_with_index do |invitee, index| %>
+              <%= render partial: "users/users_table_row_invitee", locals: { invitee: invitee, is_even: (index + users_accounts.length) % 2 == 0 } %>
+            <% end %>
           </tbody>
           <!--end::Table body-->
         </table>

--- a/server/app/views/users/_users_table_row_user_account.html.erb
+++ b/server/app/views/users/_users_table_row_user_account.html.erb
@@ -35,32 +35,34 @@
       style="font-size:14px; color: #7e8299">
   </td>
   <td class="text-end" style="padding-right: 30px">
-    <button type="button"
-            class="btn btn-sm btn-light btn-active-light-primary dropwdown-toggle"
-            data-bs-toggle="dropdown"
-            aria-expanded="false"
-            style="border-radius: 6px"
-            id="<%= "options-button-#{user_account.id}" %>"
-    >
-      Options
-      <span class="svg-icon svg-icon-5 m-0">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-            <path d="M11.4343 12.7344L7.25 8.55005C6.83579 8.13583 6.16421 8.13584 5.75 8.55005C5.33579 8.96426 5.33579 9.63583 5.75 10.05L11.2929 15.5929C11.6834 15.9835 12.3166 15.9835 12.7071 15.5929L18.25 10.05C18.6642 9.63584 18.6642 8.96426 18.25 8.55005C17.8358 8.13584 17.1642 8.13584 16.75 8.55005L12.5657 12.7344C12.2533 13.0468 11.7467 13.0468 11.4343 12.7344Z" fill="black"></path>
-          </svg>
-        </span>
-    </button>
-    <div class="dropdown-menu fw-bold fs-7 w-125px py-4"
-         aria-labelledby="<%= "options-button-#{user_account.id}" %>">
-      <!--begin::Menu item-->
-      <div class="menu-item">
-        <%= link_to "View", users_account_path(user_account, type: user_account.class.name), { class: "menu-link text-hover-gray-500 text-gray-700 px-3" } %>
+    <div class="btn-group">
+      <button type="button"
+              class="btn btn-sm btn-light btn-active-light-primary dropwdown-toggle"
+              data-bs-toggle="dropdown"
+              aria-expanded="false"
+              style="border-radius: 6px"
+              id="<%= "options-button-#{user_account.id}" %>"
+      >
+        Options
+        <span class="svg-icon svg-icon-5 m-0">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+              <path d="M11.4343 12.7344L7.25 8.55005C6.83579 8.13583 6.16421 8.13584 5.75 8.55005C5.33579 8.96426 5.33579 9.63583 5.75 10.05L11.2929 15.5929C11.6834 15.9835 12.3166 15.9835 12.7071 15.5929L18.25 10.05C18.6642 9.63584 18.6642 8.96426 18.25 8.55005C17.8358 8.13584 17.1642 8.13584 16.75 8.55005L12.5657 12.7344C12.2533 13.0468 11.7467 13.0468 11.4343 12.7344Z" fill="black"></path>
+            </svg>
+          </span>
+      </button>
+      <div class="dropdown-menu fw-bold fs-7 w-125px py-4"
+           aria-labelledby="<%= "options-button-#{user_account.id}" %>">
+        <!--begin::Menu item-->
+        <div class="menu-item">
+          <%= link_to "View", users_account_path(user_account, type: user_account.class.name), { class: "menu-link text-hover-gray-500 text-gray-700 px-3" } %>
+        </div>
+        <!--end::Menu item-->
+        <!--begin::Menu item-->
+        <div class="menu-item">
+          <%= link_to 'Remove', users_account_path(user_account, type: user_account.class.name), method: :delete, data: { confirm: 'Are you sure?' }, class: "menu-link text-hover-gray-500 text-gray-700 px-3" %>
+        </div>
+        <!--end::Menu item-->
       </div>
-      <!--end::Menu item-->
-      <!--begin::Menu item-->
-      <div class="menu-item">
-        <%= link_to 'Remove', users_account_path(user_account, type: user_account.class.name), method: :delete, data: { confirm: 'Are you sure?' }, class: "menu-link text-hover-gray-500 text-gray-700 px-3" %>
-      </div>
-      <!--end::Menu item-->
     </div>
   </td>
 </tr>


### PR DESCRIPTION
This PR includes the following issues:
TTAC-356: [Radar] Options dropdown in user page for individual user overflows in table of users (can't see drop down)
TTAC-358: [Radar] On adding new account, type dialog allows you to "unselect" org type -- remove this
TTAC-366: [Radar] Usability: When I click the account which is already selected on the navbar, should I go to that account's dashboard
TTAC-368: [Radar] Usability: When asking the account/organization name, add focus to the text field by default
TTAC-369: [Radar] Usability: Location's overview shows a "Location" option on the left menu instead of "Overview"
TTAC-370: [Radar] 404: Page not found when switching between sign in/sign up options while joining an org