### PR TITLE
Hotfix for alert from Sentry

### DIFF
--- a/server/app/controllers/users/registrations_controller.rb
+++ b/server/app/controllers/users/registrations_controller.rb
@@ -52,16 +52,16 @@ class Users::RegistrationsController < Devise::RegistrationsController
         @invite.destroy!
       end
     rescue ActiveRecord::RecordInvalid => invalid
-      error = invalid.record.errors
+      error = invalid
     rescue ActiveRecord::RecordNotDestroyed => invalid
-      error = invalid.record.errors
+      error = invalid
     end
     respond_to do |format|
       if !error
         sign_in @user
         format.html { redirect_to dashboard_path(invite: true), notice: "Registered successfully" }
       else
-        format.html { redirect_back fallback_location: root_path, status: :unprocessable_entity }
+        format.json { render json: { error: error }, status: :unprocessable_entity }
       end
     end
   end

--- a/server/app/javascript/controllers/registration_controller.js
+++ b/server/app/javascript/controllers/registration_controller.js
@@ -118,6 +118,8 @@ export default class extends Controller {
   }
 
   finishRegistrationWithInvite() {
+    this.continueButtonTarget.style.display = 'none';
+    this.finishButtonLoadingTarget.style.display = 'inline-block';
     const csrfToken = document.getElementsByName("csrf-token")[0].content;
     const accountToken = window.location.href.split("?token=")[1];
     let formData = new FormData();
@@ -136,13 +138,16 @@ export default class extends Controller {
       .then((res) => {
         if (res.redirected) {
           window.location.href = res.url;
+        } else if(res.status >= 400) {
+          return res.json();
         }
       })
+      .then(res => { this.errorTextTarget.innerText = res.error; })
       .catch((err) => handleError(err, this.identifier))
       .finally(() => {
-        this.finishButtonTarget.style.display = "block";
-        this.finishButtonLoadingTarget.style.display = "none";
-      });
+        this.continueButtonTarget.style.display = 'inline-block';
+        this.finishButtonLoadingTarget.style.display = 'none';
+      })
   }
 
   finishRegistration() {

--- a/server/app/views/devise/registrations/invite/new.html.erb
+++ b/server/app/views/devise/registrations/invite/new.html.erb
@@ -16,6 +16,7 @@
       <!--end::Heading-->
       <!--begin::Input group-->
       <div class="row fv-row mb-7 fv-plugins-icon-container">
+        <p style="color: red" data-registration-target="errorText"></p>
         <!--begin::Col-->
         <div class="col-xl-6">
           <label class="form-label fw-bolder text-dark fs-6 required">First Name</label>
@@ -144,6 +145,13 @@
                 data-action="click->registration#finishRegistrationWithInvite"
                 data-registration-target="continueButton"
         >Finish</button>
+        <button type="button"
+                class="btn btn-primary disabled"
+                style="height: 48px; display: none;"
+                data-registration-target="finishButtonLoading"
+        >
+          <div class="spinner-border text-light m-auto" role="status"></div>
+        </button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The error came from invite sign up flow, when having an error on the input data (dup email for example), it was getting stuck on the registration screen with no feedback. Added loading state + error message tag on response.

This PR includes the following issues:
TTAC-410: [Radar] Sentry alert on register from invite flow