### PR TITLE
Fix add_bytes! call when speed test has no upload information

### DIFF
--- a/server/app/jobs/process_measurement_job.rb
+++ b/server/app/jobs/process_measurement_job.rb
@@ -3,6 +3,8 @@ class ProcessMeasurementJob < ApplicationJob
 
   def perform(measurement)
     FindAsnByIp.perform_now measurement
+    measurement.download_total_bytes = 0.0
+    measurement.upload_total_bytes = 0.0
     case measurement.style
     when "NDT7"
       data = measurement.result.download.split("\n")


### PR DESCRIPTION
It appears that some measurements are being sent without the upload step. That's possible to be some issue in the library that runs it.
The issue here is that we were trying to sum a nil value, causing the exception.
