### PR TITLE
Fix Agent code Signing

### DIFF
--- a/agent/cmd/signing/main.go
+++ b/agent/cmd/signing/main.go
@@ -47,8 +47,8 @@ func main() {
 func loadKey(path string) *rsa.PrivateKey {
 	data := loadFromPath(path)
 	block, _ := pem.Decode(data)
-	key, _ := x509.ParsePKCS1PrivateKey(block.Bytes)
-	return key
+	key, _ := x509.ParsePKCS8PrivateKey(block.Bytes)
+	return key.(*rsa.PrivateKey)
 }
 
 func loadFromPath(path string) []byte {


### PR DESCRIPTION
The issue was that the key we generated after rotating was a PKCS#8 key, instead of PKCS#1