### PR TITLE
Locking Clients when updating to offline

### DIFF
--- a/server/app/models/client.rb
+++ b/server/app/models/client.rb
@@ -113,7 +113,7 @@ class Client < ApplicationRecord
 
     REDIS.zrem Client::REDIS_PING_SET_NAME, id
     Client.transaction do
-      Client.where(id: id).lock(true).update(online: false)
+      Client.where(id: id).lock().update(online: false)
     end
     self.reload
   end


### PR DESCRIPTION
This PR attempts to fix an error of duplicated offline events.

The duplicated offline events are possibly caused by a race in two different processes: 
* `clock.rb` when detecting that a pod hasn't pinged in a while
* `PodsChannel` when the channel gets disconnected

To try to avoid that, I added a lock when updating the Clients