### PR TITLE
sending missing fields in bg mode

### DIFF
--- a/speedtest_mobile/client_mobile_app/lib/core/background_fetch/background_speed_test.dart
+++ b/speedtest_mobile/client_mobile_app/lib/core/background_fetch/background_speed_test.dart
@@ -67,7 +67,7 @@ class BackgroundSpeedTest {
       if (_testingState.isTestingDownloadSpeed) {
         startUploadTest();
       } else if (_testingState.isTestingUploadSpeed) {
-        if (Platform.isAndroid && await Permission.phone.request().isGranted) {
+        if (Platform.isAndroid && await Permission.phone.isGranted) {
           _connectionInfo = await _networkConnectionInfo.getNetworkConnectionInfo();
         }
         _testingState = (isTestingDownloadSpeed: false, isTestingUploadSpeed: false);
@@ -119,6 +119,9 @@ class BackgroundSpeedTest {
     return {
       'result': _responses.isNotEmpty ? {'raw': _responses} : null,
       'speed_test': {
+        'tested_at': DateTime.now().toUtc().toIso8601String(),
+        'latitude': _positionBeforeSpeedTest?.latitude,
+        'longitude': _positionBeforeSpeedTest?.longitude,
         'latitude_before': _positionBeforeSpeedTest?.latitude,
         'longitude_before': _positionBeforeSpeedTest?.longitude,
         'accuracy_before': _positionBeforeSpeedTest?.accuracy,
@@ -137,10 +140,10 @@ class BackgroundSpeedTest {
         'speed_accuracy_after': _positionAfterSpeedTest?.speedAccuracy,
         'version_number': _packageInfo?.version,
         'build_number': _packageInfo?.buildNumber,
+        'background_mode': true,
       },
       'connection_data': _connectionInfo?.toJson(),
       'timestamp': DateTime.now().toUtc().toIso8601String(),
-      'background_mode': true,
     };
   }
 }

--- a/speedtest_mobile/client_mobile_app/lib/core/models/test_result.dart
+++ b/speedtest_mobile/client_mobile_app/lib/core/models/test_result.dart
@@ -46,7 +46,7 @@ class TestResult {
 
   Map<String, dynamic> toJsonServer() {
     return {
-      'tested_at': testedAt.toString(),
+      'tested_at': testedAt.toUtc().toIso8601String(),
       'latitude': location.latitude,
       'longitude': location.longitude,
       'altitude': location.altitude,


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* https://linear.app/exactly/issue/TTAC-1578/send-latitude-and-longitude-with-before-values-on-background-mode

## Covering the following changes:
- Bugs Fixed:
    - bg mode measurements where not showing up on map. Added the missing fields in the body.