### PR TITLE
add max height to accounts filter menu

### DIFF
--- a/server/app/assets/stylesheets/shared/sidebar.scss
+++ b/server/app/assets/stylesheets/shared/sidebar.scss
@@ -772,6 +772,8 @@
   border: solid 1px $sidebar--main-container-border;
   box-shadow: 0 4px 20px -2px $sidebar--accounts-options-box-shadow;
   backdrop-filter: blur(10px);
+  max-height: 500px;
+  overflow-y: auto;
 }
 
 .sidebar--account-filter-letter {


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [Limit accounts search filter height](https://linear.app/exactly/issue/TTAC-1580/limit-accounts-search-filter-height)

## Covering the following changes:
- Bugs Fixed:
    - Accounts filter list had no height limit + overflow control