### PR TITLE
Bug/ttac 1591

### DIFF
--- a/speedtest_mobile/client_mobile_app/lib/presentations/speed_test/steps/location_step/bloc/location_step_cubit.dart
+++ b/speedtest_mobile/client_mobile_app/lib/presentations/speed_test/steps/location_step/bloc/location_step_cubit.dart
@@ -108,7 +108,9 @@ class LocationStepCubit extends Cubit<LocationStepState> {
           speed: position.speed,
           speedAccuracy: position.speedAccuracy,
         );
-        emit(state.copyWith(isGeolocationLoading: false, geolocation: geolocation));
+        if (!isClosed) {
+          emit(state.copyWith(isGeolocationLoading: false, geolocation: geolocation));
+        }
       } else {
         useInputLocationOption();
       }
@@ -120,7 +122,11 @@ class LocationStepCubit extends Cubit<LocationStepState> {
     return location;
   }
 
-  void useInputLocationOption() => emit(state.copyWith(isUsingGeolocation: false));
+  void useInputLocationOption() {
+    if (!isClosed) {
+      emit(state.copyWith(isUsingGeolocation: false));
+    }
+  }
 
   void useGeolocationOption() {
     if (!(state.isGeolocationEnabled ?? false)) {


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* https://linear.app/exactly/issue/TTAC-1591/stateerror-bad-state-cannot-emit-new-states-after-calling-close

## Covering the following changes:
- Bugs Fixed:
    - checking if cubit is not closed before emitting new state.