### PR TITLE
bug/TTAC-1622

### DIFF
--- a/speedtest_mobile/client_mobile_app/lib/core/ndt7-client-dart/ndt7_client_dart.dart
+++ b/speedtest_mobile/client_mobile_app/lib/core/ndt7-client-dart/ndt7_client_dart.dart
@@ -95,7 +95,7 @@ void _runUploadIsolate(List<dynamic> args) async {
   final url = args[1] as String;
   final completer = Completer<void>();
   final socket = await WebSocket.connect(url, protocols: protocols);
-  DateTime startTime = DateTime.now();
+  final startTime = DateTime.now();
 
   socket.listen(
     (ev) {
@@ -131,8 +131,8 @@ Future<void> _upload(
   final completer = Completer();
   final receivePort = ReceivePort();
 
-  final isolate =
-      await Isolate.spawn<List<dynamic>>(_runUploadIsolate, [receivePort.sendPort, url], debugName: 'UploadIsolate');
+  final isolate = await Isolate.spawn<List<dynamic>>(_runUploadIsolate, [receivePort.sendPort, url],
+      debugName: 'UploadIsolate');
   receivePort.listen(
     (data) {
       if (data is Map<String, dynamic>) {
@@ -165,7 +165,8 @@ Future<void> _download(
   final completer = Completer();
   final receivePort = ReceivePort();
 
-  final isolate = await Isolate.spawn<List<dynamic>>(_runDownloadIsolate, [receivePort.sendPort, url],
+  final isolate = await Isolate.spawn<List<dynamic>>(
+      _runDownloadIsolate, [receivePort.sendPort, url],
       debugName: 'DownloadIsolate');
   receivePort.listen(
     (data) {

--- a/speedtest_mobile/client_mobile_app/lib/presentations/speed_test/steps/take_speed_test_step/bloc/take_speed_test_step_cubit.dart
+++ b/speedtest_mobile/client_mobile_app/lib/presentations/speed_test/steps/take_speed_test_step/bloc/take_speed_test_step_cubit.dart
@@ -74,8 +74,9 @@ class TakeSpeedTestStepCubit extends Cubit<TakeSpeedTestStepState> {
         emit(
           state.copyWith(
             isTestingDownloadSpeed: false,
+            downloadSpeed: response['LastClientMeasurement']['MeanClientMbps'],
             latency: (state.minRtt ?? 0) / 1000,
-            loss: (state.bytesRetrans ?? 0) / (state.bytesSent ?? 0) * 100,
+            loss: (state.bytesRetrans ?? 0) / (state.bytesSent ?? 1) * 100,
             responses: updatedResponses,
           ),
         );
@@ -87,6 +88,7 @@ class TakeSpeedTestStepCubit extends Cubit<TakeSpeedTestStepState> {
               .getNetworkConnectionInfo()
               .then((connectionInfo) => emit(state.copyWith(
                     isTestingUploadSpeed: false,
+                    uploadSpeed: response['LastClientMeasurement']['MeanClientMbps'],
                     finishedTesting: true,
                     responses: updatedResponses,
                     connectionInfo: connectionInfo,
@@ -100,6 +102,7 @@ class TakeSpeedTestStepCubit extends Cubit<TakeSpeedTestStepState> {
             isTestingUploadSpeed: false,
             responses: updatedResponses,
             positionAfterSpeedTest: positionAfterSpeedTest,
+            uploadSpeed: response['LastClientMeasurement']['MeanClientMbps'],
           ));
         }
       }


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [[Task](https://linear.app)](https://linear.app/exactly/issue/TTAC-1622/unify-the-upload-and-download-values-being-used)

## Covering the following changes:
- Bugs Fixed:
    - now the map and the mobile app will show the same download and upload values