### PR TITLE
Possible fix for instance reutilization on map controller

### DIFF
--- a/server/app/javascript/controllers/map_controller.js
+++ b/server/app/javascript/controllers/map_controller.js
@@ -6,14 +6,6 @@ let map;
 
 export default class extends Controller {
 
-  disconnect() {
-    // clear map so it can get properly initialized on re-render
-    if (map) {
-      map.off();
-      map.remove();
-    }
-  }
-
   connect() {
     if (!document.querySelector("#map")) return; // don't try to initialize a map if the <div id="map"> is not present on the screen
     


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [Error: Map container is being reused by another instance](https://linear.app/exactly/issue/TTAC-1755/error-map-container-is-being-reused-by-another-instance)

Completes TTAC-1755.

## Covering the following changes:
- Bugs Fixed:
    - Possible fix for map container reutilization issue