### PR TITLE
Fix super user account scoping on member sharing

### DIFF
--- a/server/app/controllers/shared_users_account_controller.rb
+++ b/server/app/controllers/shared_users_account_controller.rb
@@ -26,7 +26,7 @@ class SharedUsersAccountController < ApplicationController
     end
 
     respond_to do |format|
-      format.html { redirect_back fallback_location: root_path, notice: "Account sharing correctly saved!" }
+      format.html { redirect_back fallback_location: root_path, notice: "Account sharing updated successfully." }
     end
   end
 

--- a/server/app/views/users/shared.html.erb
+++ b/server/app/views/users/shared.html.erb
@@ -47,7 +47,7 @@
                 name="share_to[]"
                 data-is-multi="true"
               >
-                <% current_user.accounts.not_deleted.distinct.where.not(id: current_account.id).each do |account| %>
+                <% policy_scope(Account).not_deleted.distinct.where.not(id: current_account.id).each do |account| %>
                   <option value="<%= account.id %>" label="<%= account.name %>" <%= policy_scope(SharedAccount).where(shared_to_account_id: account.id).count == 1 ? "selected" : nil %>><%= account.name %></option>
                 <% end %>
               </select>


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [Super user should be able to share from / to any account](https://linear.app/exactly/issue/TTAC-1757/[1757]-super-user-should-be-able-to-share-from-to-any-account)

Completes TTAC-1757.

## Covering the following changes:
- Bugs Fixed:
    - Fixed super user being able to share to and from any account in the system