### PR TITLE
latency and loss rounded to whole numbers

### DIFF
--- a/server/app/jobs/process_speed_test_job.rb
+++ b/server/app/jobs/process_speed_test_job.rb
@@ -31,7 +31,7 @@ class ProcessSpeedTestJob < ApplicationJob
 
     bytes_retrans = tcp_info.fetch('BytesRetrans', 0)
     bytes_sent = tcp_info.fetch('BytesSent', 0)
-    bytes_retrans / (bytes_sent * 100) if bytes_sent.positive?
+    (bytes_retrans / (bytes_sent * 100.0)).round(2) if bytes_sent.positive?
   end
 
   def get_latency(result)
@@ -39,6 +39,6 @@ class ProcessSpeedTestJob < ApplicationJob
     return if tcp_info.nil?
 
     min_rtt = tcp_info.fetch('MinRTT', nil)
-    min_rtt / 1000 unless min_rtt.nil?
+    min_rtt / 1000.0 unless min_rtt.nil?
   end
 end

--- a/server/test/jobs/process_speed_test_job_test.rb
+++ b/server/test/jobs/process_speed_test_job_test.rb
@@ -33,8 +33,8 @@ class ProcessSpeedTestJobTest < ActiveJob::TestCase
                                             'result_with_lastServerMeasurement_on_upload_nil.json')
     measurement = ClientSpeedTest.last
     assert has_performed
-    assert_equal measurement.loss, 0
-    assert_equal measurement.latency, 63.0
+    assert_equal measurement.loss, 0.0
+    assert_equal measurement.latency, 63.303
     assert_equal measurement.download_id, 'ndt-bx8km_1685156513_0000000000340D1E'
     assert_nil measurement.upload_id
   end
@@ -55,8 +55,8 @@ class ProcessSpeedTestJobTest < ActiveJob::TestCase
                                             'result_with_lastServerMeasurement_on_download_and_upload.json')
     measurement = ClientSpeedTest.last
     assert has_performed
-    assert_equal measurement.loss, 0
-    assert_equal measurement.latency, 4
+    assert_equal measurement.loss, 0.0
+    assert_equal measurement.latency, 4.276
     assert_equal measurement.download_id, 'ndt-879bs_1679080442_000000000010F49A'
     assert_equal measurement.upload_id, 'ndt-879bs_1679080442_000000000010762D'
   end


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [Review latency trend in metabase - latency rounded to whole numbers](https://linear.app/exactly/issue/TTAC-1743/review-latency-trend-in-metabase-latency-rounded-to-whole-numbers)

Completes TTAC-1743.

## Covering the following changes:
- Bugs Fixed:
    - The division at the time of calculating latency or loss was casting the response.