### PR TITLE
Fix account scoping + added sleep on mocked tests

### DIFF
--- a/pods_agent/services/ndt7/mockndt7.go
+++ b/pods_agent/services/ndt7/mockndt7.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"log"
-
+	"time"
 	"github.com/exactlylabs/radar/pods_agent/agent"
 )
 
@@ -28,6 +28,7 @@ func (r *Ndt7MockRunner) Run(ctx context.Context) (*agent.Measurement, error) {
 	if r.Err != nil {
 		return nil, r.Err
 	}
+	time.Sleep(10 * time.Second)
 
 	return &agent.Measurement{
 		Raw:          mockResult,

--- a/pods_agent/services/ooklarunner/mockookla.go
+++ b/pods_agent/services/ooklarunner/mockookla.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"log"
-
+	"time"
 	"github.com/exactlylabs/radar/pods_agent/agent"
 )
 
@@ -28,6 +28,7 @@ func (r *OoklaMockRunner) Run(ctx context.Context) (*agent.Measurement, error) {
 	if r.Err != nil {
 		return nil, r.Err
 	}
+	time.Sleep(10 * time.Second)
 
 	return &agent.Measurement{
 		Raw:          mockResult,

--- a/server/app/views/accounts/modals/create/_share_step_modal.html.erb
+++ b/server/app/views/accounts/modals/create/_share_step_modal.html.erb
@@ -30,7 +30,8 @@
         data-is-multi="true"
         data-action="select2-select->add-account#handleSharedToAccountSelect select2-unselect->add-account#handleSharedToAccountSelect"
       >
-        <% current_user.accounts.not_deleted.distinct.where.not(id: current_account.id).each do |account| %>
+      
+        <% policy_scope(Account).not_deleted.distinct.where.not(id: current_account.id).each do |account| %>
           <option value="<%= account.id %>"
             label="<%= account.name %>"
             data-add-account-target="shareOption"


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [Update shared accounts dropdown on account creation wizard](https://linear.app/exactly/issue/TTAC-1768/[1768]-update-shared-accounts-dropdown-on-account-creation-wizard)
* [Add delay to Mocked speed tests on the agent](https://linear.app/exactly/issue/TTAC-1662/[1768]-add-delay-to-mocked-speed-tests-on-the-agent)

Completes TTAC-1768 and TTAC-1662.

## Covering the following changes:
- Features:
    - Add sleep to mocked tests on agent
- Bugs Fixed:
    - Missing accounts on super user account creation modal