### PR TITLE
Notification permission is not prompting

### DIFF
--- a/speedtest_mobile/client_mobile_app/android/app/src/main/AndroidManifest.xml
+++ b/speedtest_mobile/client_mobile_app/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         tools:replace="android:label"

--- a/speedtest_mobile/client_mobile_app/lib/presentations/speed_test/steps/location_step/bloc/location_step_cubit.dart
+++ b/speedtest_mobile/client_mobile_app/lib/presentations/speed_test/steps/location_step/bloc/location_step_cubit.dart
@@ -173,6 +173,7 @@ class LocationStepCubit extends Cubit<LocationStepState> {
       street: location?.street,
       postalCode: location?.postalCode,
     );
+    if (isClosed) return;
     emit(state.copyWith(geolocation: accurateGeolocation));
   }
 

--- a/speedtest_mobile/client_mobile_app/lib/presentations/speed_test/widgets/app_info_modal/background_mode_bloc/background_mode_cubit.dart
+++ b/speedtest_mobile/client_mobile_app/lib/presentations/speed_test/widgets/app_info_modal/background_mode_bloc/background_mode_cubit.dart
@@ -177,6 +177,7 @@ class BackgroundModeCubit extends Cubit<BackgroundModeState> {
 
   Future<bool> _requestAccessToNotifications() async =>
       await Permission.notification.request().isGranted;
+
   Future<void> _loadWarnings() => _warningsService.getWarnings();
 
   void _listenToWarnings() {


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [StateError: Bad state: Cannot emit new states after calling close](https://linear.app/exactly/issue/TTAC-1807/stateerror-bad-state-cannot-emit-new-states-after-calling-close)
* [Notification permission is not prompting](https://linear.app/exactly/issue/TTAC-1812/notification-permission-is-not-prompting)

Completes TTAC-1807 and TTAC-1812.

## Covering the following changes:
- Bugs Fixed:
    - Notification permission is not prompting
    - Emitting new state after bloc closed