### PR TITLE
Multiple bugfixes

### DIFF
--- a/server/app/controllers/users/registrations_controller.rb
+++ b/server/app/controllers/users/registrations_controller.rb
@@ -4,13 +4,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
   prepend_before_action :authenticate_scope!, only: [:edit, :edit_email, :update, :update_email, :destroy]
   prepend_before_action :set_minimum_password_length, only: [:new, :edit, :edit_email]
   before_action :set_invite, only: [:render_invite_sign_up, :render_invite_sign_in, :sign_from_invite, :create_from_invite]
-  # before_action :configure_sign_up_params, only: [:create]
-  # before_action :configure_account_update_params, only: [:update]
-
-  # GET /resource/sign_up
-  # def new
-  #   super
-  # end
 
   # POST /register
   def create
@@ -272,40 +265,4 @@ class Users::RegistrationsController < Devise::RegistrationsController
       raise ActiveRecord::RecordNotFound.new("Couldn't find Invite", Invite.name)
     end
   end
-
-  # DELETE /resource
-  # def destroy
-  #   super
-  # end
-
-  # GET /resource/cancel
-  # Forces the session data which is usually expired after sign
-  # in to be expired now. This is useful if the user wants to
-  # cancel oauth signing in/up in the middle of the process,
-  # removing all OAuth session data.
-  # def cancel
-  #   super
-  # end
-
-  # protected
-
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-  # end
-
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_account_update_params
-  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
-  # end
-
-  # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
-
-  # The path used after sign up for inactive accounts.
-  # def after_inactive_sign_up_path_for(resource)
-  #   super(resource)
-  # end
 end

--- a/server/app/javascript/map.js
+++ b/server/app/javascript/map.js
@@ -78,7 +78,7 @@ export function getPopupElement(location) {
                 >${!!uploadDiff ? uploadDiff : '-'}</span>
             </div>
           </div>
-          <a href="/clients/${locationId}" class="w-100 custom-button custom-button--secondary custom-button--lg">
+          <a href="/locations/${locationId}" class="w-100 custom-button custom-button--secondary custom-button--lg">
             View details
           </a>
         </div>

--- a/server/app/mailers/application_mailer.rb
+++ b/server/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'no-reply@radar.exactlylabs.com'
+  default from: 'no-reply@pods.radartoolkit.com'
   layout 'mailer'
 end

--- a/server/app/views/accounts/modals/create/_share_step_modal.html.erb
+++ b/server/app/views/accounts/modals/create/_share_step_modal.html.erb
@@ -30,8 +30,7 @@
         data-is-multi="true"
         data-action="select2-select->add-account#handleSharedToAccountSelect select2-unselect->add-account#handleSharedToAccountSelect"
       >
-      
-        <% policy_scope(Account).not_deleted.distinct.where.not(id: current_account.id).each do |account| %>
+        <% policy_scope(Account).not_deleted.distinct.where.not(id: current_account&.id).each do |account| %>
           <option value="<%= account.id %>"
             label="<%= account.name %>"
             data-add-account-target="shareOption"

--- a/server/app/views/dashboard/_create_account.html.erb
+++ b/server/app/views/dashboard/_create_account.html.erb
@@ -25,7 +25,7 @@
           <a href="<%= new_account_path %>"
             class="custom-button custom-button--primary custom-button--lg mx-auto"
             data-turbo-frame="create_account_modal"
-          >Add new account</a>
+          >Create an account</a>
         </div>
       </div>
       <!--end::Row-->

--- a/server/app/views/dashboard/_no_accounts_card.html.erb
+++ b/server/app/views/dashboard/_no_accounts_card.html.erb
@@ -4,5 +4,8 @@
   </div>
   <h2 class="dialog-main-title mb-3 wrap">You haven't set up an account yet.</h2>
   <p class="text-wrap additional-text wrap w-100 mb-8">Radar is great for both personal use and for organizations. Let’s set up a new account so you can get started.</p>
-  <a href="#" class="custom-button custom-button--primary custom-button--lg mx-auto" data-bs-toggle="modal" data-bs-target="#add_account_wizard">Add new account</a>
+  <a href="<%= new_account_path %>"
+    class="custom-button custom-button--primary custom-button--lg mx-auto"
+    data-turbo-frame="create_account_modal"
+  >Create an account</a>
 </div>

--- a/server/app/views/devise/passwords/new.html.erb
+++ b/server/app/views/devise/passwords/new.html.erb
@@ -31,7 +31,11 @@
       <!--end::Actions-->
     <% end %>
     <!--end::Form-->
-    <%= link_to 'Back to log in', new_session_path(resource_name), class: "regular-link" %>
+    <% if params[:token].present? %>
+      <%= link_to 'Back to log in', users_invite_sign_in_path(token: params[:token]), class: "regular-link" %>
+    <% else %>
+      <%= link_to 'Back to log in', new_session_path(resource_name), class: "regular-link" %>
+    <% end %>
   </div>
   <!--end::Wrapper-->
 </div>

--- a/server/app/views/devise/registrations/invite/new.html.erb
+++ b/server/app/views/devise/registrations/invite/new.html.erb
@@ -13,7 +13,7 @@
       data-alert-type="warning"
       data-registration-target="duplicatedEmailAlert"
     >
-      This email address is already being used. You can <a href="<%= new_session_path(resource_name) %>" class="warning-link">log in</a> in instead.
+      This email address is already being used. You can <a href="<%= users_invite_sign_in_path(token: params[:token]) %>" class="warning-link">log in</a> instead.
     </div>
 
     <div class="mt-2 devise--alert wrap invisible"

--- a/server/app/views/devise/registrations/new.html.erb
+++ b/server/app/views/devise/registrations/new.html.erb
@@ -13,7 +13,7 @@
       data-alert-type="warning"
       data-registration-target="duplicatedEmailAlert"
     >
-      This email address is already being used. You can <a href="<%= new_session_path(resource_name) %>" class="warning-link">log in</a> in instead.
+      This email address is already being used. You can <a href="<%= new_session_path(resource_name) %>" class="warning-link">log in</a> instead.
     </div>
 
     <div class="mt-2 devise--alert wrap invisible"

--- a/server/app/views/devise/sessions/invite/new.html.erb
+++ b/server/app/views/devise/sessions/invite/new.html.erb
@@ -73,9 +73,7 @@
 				<!--end::Submit button-->
 				<div class="d-flex flex-stack mb-2 mt-6 mx-auto text-center">
 					<!--begin::Link-->
-					<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-						<a href="<%= new_password_path(resource_name) %>" class="regular-link w-100 text-center" tabindex="4">Forgot your password?</a>
-					<% end %>
+					<a href="<%= new_password_path(resource_name, token: params[:token]) %>" class="regular-link w-100 text-center" tabindex="4">Forgot your password?</a>
 					<!--end::Link-->
 				</div>
 			</div>

--- a/server/app/views/invite_mailer/invite_email.html.erb
+++ b/server/app/views/invite_mailer/invite_email.html.erb
@@ -24,7 +24,7 @@
       </div>
       <div style="font-size: 16px;">If you experience difficulties setting up your account, please contact support@exactlylabs.com.</div>
       <div style="height: 2px; width: 100%; margin-bottom: 40px; margin-top: 30px; background-color: #f6f8fa;"></div>
-      <div style="color: #b5b5c3; text-align: center; font-size: 14px">© 2022 National Telehealth Technology Assessment Resource Center</div>
+      <div style="color: #b5b5c3; text-align: center; font-size: 14px">© 2023 National Telehealth Technology Assessment Resource Center</div>
     </div>
   </body>
 </html>

--- a/server/app/views/layouts/application.html.erb
+++ b/server/app/views/layouts/application.html.erb
@@ -10,13 +10,13 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A==" crossorigin="" />
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbo-track': 'reload' %>
-    <script
-      src="https://browser.sentry-cdn.com/7.9.0/bundle.min.js"
-      integrity="sha384-4Q6VnoFQcxYhNxg1ic5R+RRx0fam6rRf9PFAE3oTZhtTV2S8IM7uyl8Bg2z3AFi9"
-      crossorigin="anonymous"
-    ></script>
     <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js" integrity="sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA==" crossorigin=""></script>
     <% if Rails.env.production? %>
+      <script
+        src="https://browser.sentry-cdn.com/7.9.0/bundle.min.js"
+        integrity="sha384-4Q6VnoFQcxYhNxg1ic5R+RRx0fam6rRf9PFAE3oTZhtTV2S8IM7uyl8Bg2z3AFi9"
+        crossorigin="anonymous"
+      ></script>
       <script>
         // based on sentry.rb file config
         Sentry.init({

--- a/server/app/views/locations/index.html.erb
+++ b/server/app/views/locations/index.html.erb
@@ -58,7 +58,7 @@
 
 <% if FeatureFlagHelper.is_available('networks', current_user) && are_there_unassigned_pods? %>
   <div class="networks--unassigned-pods-banner">
-    <%= image_tag image_url('warning-icon'), width: 20, height: 20 %>
+    <%= image_tag image_url('warning-icon.png'), width: 20, height: 20 %>
     <div class="networks--unassigned-pods-banner-text-container">
       <% pod_count = policy_scope(Client).where(location: nil).count %>
       <span class="forms--label wrap">You have <%= pod_count %> pod<%= pod_count > 1 ? 's' : ''%> not assigned to any network.</span>

--- a/server/app/views/public_pod/_status_page.html.erb
+++ b/server/app/views/public_pod/_status_page.html.erb
@@ -20,7 +20,7 @@
 
   <div class="public--horizontal-divider"></div>
 
-  <% if client.location&.latest_measurement.nil? %>
+  <% if client.location&.latest_measurement&.download.nil?%>
     <div class="public--no-measurement-container mb-8">
       <div class="public--no-measurement-icons-container">
         <div class="public--no-measurement-icon-container me-4">
@@ -83,14 +83,14 @@
       <div class="public--status-card-speed">
         <%= image_tag image_url('download-icon-blue.png'), class: "public--arrow-icon" %>
         <p class="regular-bold-text mb-1">Avg Download Speed</p>
-        <p class="additional-text m-0 text-left wrap"><%= client.location&.latest_measurement.nil? ? "N/A" : "#{client.location.measurements.average(:download).round(1)} Mbps" %></p>
+        <p class="additional-text m-0 text-left wrap"><%= client.location&.measurements.count == 0 ? "N/A" : "#{client.location.measurements.average(:download).to_f.round(1)} Mbps" %></p>
       </div>
     </div>
     <div class="public--status-card half">
       <div class="public--status-card-speed">
         <%= image_tag image_url('upload-icon-blue.png'), class: "public--arrow-icon" %>
         <p class="regular-bold-text mb-1">Avg Upload Speed</p>
-        <p class="additional-text m-0 text-left wrap"><%= client.location&.latest_measurement.nil? ? "N/A" : "#{client.location.measurements.average(:upload).round(1)} Mbps" %></p>
+        <p class="additional-text m-0 text-left wrap"><%= client.location&.measurements.count == 0 ? "N/A" : "#{client.location.measurements.average(:upload).to_f.round(1)} Mbps" %></p>
       </div>
     </div>
   </div>

--- a/server/config/initializers/devise.rb
+++ b/server/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'no-reply@radar.exactlylabs.com'
+  config.mailer_sender = 'no-reply@pods.radartoolkit.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [Invite sign up warning message: broken "log in instead" link](https://linear.app/exactly/issue/TTAC-1825/[1825]-invite-sign-up-warning-message-broken-log-in-instead-link)
* [ActionView::Template::Error: undefined method `id' for nil:NilClass](https://linear.app/exactly/issue/TTAC-1823/[1825]-actionviewtemplateerror-undefined-method-id-for-nilnilclass)
* [On the Pods Dashboard, the view details appears to link to the client url and not the locations url](https://linear.app/exactly/issue/TTAC-1813/[1825]-on-the-pods-dashboard-the-view-details-appears-to-link-to-the)
* [ActionView::Template::Error: undefined method `round' for nil:NilClass](https://linear.app/exactly/issue/TTAC-1810/[1825]-actionviewtemplateerror-undefined-method-round-for-nilnilclass)
* [ActionView::Template::Error: The asset "warning-icon" is not present in the asset pipeline.](https://linear.app/exactly/issue/TTAC-1816/[1825]-actionviewtemplateerror-the-asset-warning-icon-is-not-present)
* [Add an account modal opening issue](https://linear.app/exactly/issue/TTAC-1831/[1825]-add-an-account-modal-opening-issue)
* [ReferenceError: L is not defined](https://linear.app/exactly/issue/TTAC-1828/[1825]-referenceerror-l-is-not-defined)
* [Update mailer email to pods.radartoolkit.com](https://linear.app/exactly/issue/TTAC-1838/[1825]-update-mailer-email-to-podsradartoolkitcom)

Completes TTAC-1825, TTAC-1823, TTAC-1813, TTAC-1810, TTAC-1816, TTAC-1831, TTAC-1828 and TTAC-1838.

## Covering the following changes:
- Bugs Fixed:
    - Fixed broken link in invite already existing email warning message.
    - Fixed issues on initial account creation
    - Fixed broken locations link on dashboard map tooltip
    - Fixed old email domain being used
    - Fixed public page issues when measurement has no download/upload value
    - Possible fix for leaflet import race condition
    - [Behind FF] Fixed missing asset extension on networks index page