### PR TITLE
Fix all accounts measurements policy

### DIFF
--- a/server/app/policies/measurement_policy.rb
+++ b/server/app/policies/measurement_policy.rb
@@ -7,14 +7,8 @@ class MeasurementPolicy < ApplicationPolicy
       if @auth_holder.present?
         if @auth_holder.is_all_accounts?
           user = @auth_holder.user
-          all_measurements = []
-          user.accounts.not_deleted.each do |account|
-            all_measurements.append(*account.measurements.where.not(download: nil).pluck(:id))
-          end
-          user.shared_accounts.not_deleted.each do |account|
-            all_measurements.append(*account.measurements.where.not(download: nil).pluck(:id))
-          end
-          scope.where(id: all_measurements)
+          accounts = [*user.accounts.not_deleted, *user.shared_accounts.not_deleted]
+          scope.where(account: accounts).where.not(download: nil)
         else
           scope.where(account_id: @auth_holder.account.id).where('download IS NOT NULL') # Prevent from seeing tests from different accounts where the test wasn't taken
         end


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [Measurements on all accounts timeout](https://linear.app/exactly/issue/TTAC-1850/[1850]-measurements-on-all-accounts-timeout)

Completes TTAC-1850.

## Covering the following changes:
- Bugs Fixed:
    - Fix nginx timeout on all accounts measurements download