### PR TITLE
Bugs fixing on radar projects

### DIFF
--- a/speedtest/src/components/AllResultsPage/MyCustomMarker.jsx
+++ b/speedtest/src/components/AllResultsPage/MyCustomMarker.jsx
@@ -23,11 +23,11 @@ const MyCustomMarker = ({
 }) => {
 
   const getPathOptions = () => {
-    const { downloadFilterTag, uploadFilterTag, visible } = measurement;
+    const { downloadFilterTag, uploadFilterTag } = measurement;
     let pathOptions = {
       ...sharedMarkerProps,
-      opacity: visible ? 1.0 : 0.1,
-      fillOpacity: visible ? 0.7 : 0.1,
+      opacity: 1.0,
+      fillOpacity: 0.7,
     };
     const tagToCheck = currentFilterType === 'download' ? downloadFilterTag : uploadFilterTag;
     const thresholdToConsider = currentFilterType === 'download' ? DOWNLOAD_FILTER_TAGS : UPLOAD_FILTER_TAGS;
@@ -55,6 +55,8 @@ const MyCustomMarker = ({
       fillColor: DEFAULT_DOWNLOAD_FILTER_HIGH
     };
   };
+
+  if(!measurement.visible) return;
 
   return (
     <CircleMarker

--- a/speedtest/src/components/StepsPage/Pages/LocationSearchStep/AddressInput/MyAddressInput.jsx
+++ b/speedtest/src/components/StepsPage/Pages/LocationSearchStep/AddressInput/MyAddressInput.jsx
@@ -185,7 +185,9 @@ const MyAddressInput = ({
       });
       handleContinue(address.address, true);
       const addressInputElement = document.getElementById('speedtest--address-input');
-      addressInputElement.value = address.address;
+      if(addressInputElement) {
+        addressInputElement.value = address.address;
+      }
     } catch (e) {
       if(isNoConnectionError(e)) setNoInternet(true);
       notifyError(e);

--- a/toolkit_website/src/components/Frame/Footer/Footer.tsx
+++ b/toolkit_website/src/components/Frame/Footer/Footer.tsx
@@ -17,13 +17,13 @@ interface FooterProps {
 
 // Not doing 2 different components for viewport changes as they are
 // pretty small components on their own and quite a lot of shared styles.
-const Footer = ({isDifferentColor, height, margin, smallFooterMarginTop}: FooterProps): ReactElement => {
+const Footer = ({isDifferentColor, margin, smallFooterMarginTop}: FooterProps): ReactElement => {
 
   const {isSmallScreen, isMidScreen} = useViewportSizes();
   const isSmall = isSmallScreen || isMidScreen;
 
   const regularFooter = (
-    <div style={styles.Footer(isDifferentColor, height)}>
+    <div style={styles.Footer(isDifferentColor)}>
       <div style={styles.FooterContent(margin)}>
         <div style={styles.TopRow}>
           <div style={styles.LeftColumn}>
@@ -42,6 +42,7 @@ const Footer = ({isDifferentColor, height, margin, smallFooterMarginTop}: Footer
             </a>
           </div>
         </div>
+        <div style={styles.FooterHorizontalDivider}></div>
         <div style={styles.BottomRow}>
           <p className={'fw-regular'} style={styles.Copyright}>{`Copyright © ${new Date().getFullYear()} Radar. All rights reserved.`}</p>
           <p className={'fw-regular'} style={styles.DeveloperInfo}>This project was developed as part of the Telehealth Broadband Pilot Program.<br/>The Telehealth Broadband Pilot Program is made possible by grant #GA540183 from the Office for the Advancement of Telehealth, Health Resources and Services Administration, DHHS.</p>

--- a/toolkit_website/src/components/Frame/Footer/styles/Footer.style.ts
+++ b/toolkit_website/src/components/Frame/Footer/styles/Footer.style.ts
@@ -3,7 +3,6 @@ import {DEFAULT_SECONDARY_TEXT, HORIZONTAL_DIVIDER, SPECIAL_FOOTER} from "../../
 
 const footerStyle: CSSProperties = {
   width: '100vw',
-  height: '375px',
   marginLeft: 'auto',
   marginRight: 'auto',
   display: 'flex',
@@ -166,10 +165,10 @@ const smallBottomRowStyle: CSSProperties = {
 }
 
 const footerHorizontalDividerStyle: CSSProperties = {
-  width: '100vw',
+  width: '100%',
   height: '1px',
   backgroundColor: HORIZONTAL_DIVIDER,
-  marginTop: '20px',
+  marginTop: '40px',
   marginBottom: '40px',
 }
 
@@ -184,10 +183,9 @@ const footerContentStyle: CSSProperties = {
 }
 
 export const styles = {
-  Footer: (isDifferentColor?: boolean, height?: string) => {
+  Footer: (isDifferentColor?: boolean) => {
     let style = footerStyle;
     if(isDifferentColor) style = {...style, backgroundColor: SPECIAL_FOOTER};
-    if(height) style = {...style, height};
     return style;
   },
   FooterContent: (margin?: string) => {

--- a/toolkit_website/src/components/Frame/Frame.tsx
+++ b/toolkit_website/src/components/Frame/Frame.tsx
@@ -6,12 +6,11 @@ import Footer from "./Footer/Footer";
 interface FrameProps {
   children: ReactElement;
   isDifferentColorFooter?: boolean;
-  footerHeight?: string;
   footerMargin?: string;
   smallFooterMarginTop?: string;
 }
 
-const Frame = ({ children, isDifferentColorFooter, footerHeight,  footerMargin, smallFooterMarginTop }: FrameProps): ReactElement => {
+const Frame = ({ children, isDifferentColorFooter,  footerMargin, smallFooterMarginTop }: FrameProps): ReactElement => {
   return (
     <div style={styles.Frame}>
       <Navbar/>
@@ -19,7 +18,6 @@ const Frame = ({ children, isDifferentColorFooter, footerHeight,  footerMargin, 
         {children}
       </div>
       <Footer isDifferentColor={isDifferentColorFooter}
-              height={footerHeight}
               margin={footerMargin}
               smallFooterMarginTop={smallFooterMarginTop}
       />

--- a/toolkit_website/src/components/PrivacyPolicyPage/PrivacyPolicyContent.tsx
+++ b/toolkit_website/src/components/PrivacyPolicyPage/PrivacyPolicyContent.tsx
@@ -10,8 +10,7 @@ const PrivacyPolicyContent = (): ReactElement => {
 
   return (
     <Frame isDifferentColorFooter
-           footerHeight={!isSmall ? '188px' : undefined}
-           footerMargin={!isSmall ? '35px auto auto' : undefined}
+          footerMargin={!isSmall ? '35px auto auto' : undefined}
     >
       <div style={styles.PrivacyPolicyPage(isSmall)}>
         <div style={styles.PrivacyPolicyPageContent(isSmall)}>


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [Additional issue: Hidden dots can still be clicked on](https://linear.app/exactly/issue/TTAC-1863/additional-issue-hidden-dots-can-still-be-clicked-on)
* [Bug: When filtering the map by level of service delivered, the dots are grayed out](https://linear.app/exactly/issue/TTAC-1814/bug-when-filtering-the-map-by-level-of-service-delivered-the-dots-are)
* [Bugs related to the implementation of grant specific language to the radar website](https://linear.app/exactly/issue/TTAC-1840/bugs-related-to-the-implementation-of-grant-specific-language-to-the)
* [Line separating grant specific language is missing in implementation](https://linear.app/exactly/issue/TTAC-1842/line-separating-grant-specific-language-is-missing-in-implementation)
* [Background is cut off on all views except for the Radar Overview page](https://linear.app/exactly/issue/TTAC-1841/background-is-cut-off-on-all-views-except-for-the-radar-overview-page)
* [Validate speed test data generated by session ID 3zOa0UYBoM](https://linear.app/exactly/issue/TTAC-1815/validate-speed-test-data-generated-by-session-id-3zoa0uybom)
* [TypeError: Failed to fetch](https://linear.app/exactly/issue/TTAC-1801/typeerror-failed-to-fetch)
* [TypeError: Cannot set properties of null (setting 'value')](https://linear.app/exactly/issue/TTAC-1791/typeerror-cannot-set-properties-of-null-setting-value)

Completes TTAC-1836, TTAC-1863, TTAC-1814, TTAC-1840, TTAC-1842, TTAC-1841, TTAC-1815, TTAC-1801 and TTAC-1791.

## Covering the following changes:
- Bugs Fixed:
    - Now hidden dots can not be clicked on results map.
    - Added missing horizontal divider on website footer.
    - Now footer background is not cut off on radar websites.
    - Fixed background service after validating a wrong behavior with the session_id: 3zoa0uybom.
    - Not setting properties on null.