### PR TITLE
Update location picking step given new design

### DIFF
--- a/speedtest/src/components/StepsPage/Pages/LocationSearchStep/AddressInput/MyAddressInput.jsx
+++ b/speedtest/src/components/StepsPage/Pages/LocationSearchStep/AddressInput/MyAddressInput.jsx
@@ -101,6 +101,7 @@ const MyAddressInput = ({
   handleContinue,
   setGeolocationError,
   openGenericLocationModal,
+  openCurrentLocationModal,
   confirmedAddress,
   setSelectedSuggestion,
   selectedSuggestion,
@@ -164,7 +165,7 @@ const MyAddressInput = ({
     }
   }
 
-  const fetchAddress = async (coords) => {
+  const fetchAddress = async (coords, isGeolocation = false) => {
     try {
       const coordinates = [coords.latitude, coords.longitude];
       const address = await getAddressForCoordinates(coordinates, config.clientId);
@@ -172,7 +173,12 @@ const MyAddressInput = ({
         openGenericLocationModal();
         return;
       }
-      setSelectedSuggestion(true);
+      if (isGeolocation) { 
+        openCurrentLocationModal(true); 
+      } else { 
+        setSelectedSuggestion(true); 
+      }
+
       setUserData({
         ...userData,
         address,
@@ -203,7 +209,7 @@ const MyAddressInput = ({
     if ('geolocation' in navigator) {
       navigator.geolocation.getCurrentPosition(
         pos => {
-          fetchAddress(pos.coords)
+          fetchAddress(pos.coords, true)
             .catch(err => {
               notifyError(err);
               setError(err);
@@ -246,52 +252,52 @@ const MyAddressInput = ({
     <div id={'speedtest--address-input-wrapper'}>
       <div style={addressInputWrapperStyle} id={'speedtest--address-input-container'}>
         <TextField placeholder={'Enter your address or zip code'}
-                   id={'speedtest--address-input'}
-                   sx={{width: '100%'}}
-                   InputProps={addressInputStyle}
-                   error={!!error}
-                   onChange={handleInputChange}
-                   onFocus={handleOpenSuggestions}
-                   onBlur={handleBlurInput}
-                   variant={'standard'}
+          id={'speedtest--address-input'}
+          sx={{width: '100%'}}
+          InputProps={addressInputStyle}
+          error={!!error}
+          onChange={handleInputChange}
+          onFocus={handleOpenSuggestions}
+          onBlur={handleBlurInput}
+          variant={'standard'}
         />
         <div className={!!userData.address?.address ? 'speedtest--opaque-hoverable' : ''}
-             style={inputAdornmentStyle}
-             id={'speedtest--continue-button'}
-             onClick={!!userData.address?.address ? checkClickConditions : undefined}
+          style={inputAdornmentStyle}
+          id={'speedtest--continue-button'}
+          onClick={!!userData.address?.address ? checkClickConditions : undefined}
         >
           <div style={!!userData.address?.address ? continueButtonStyle : disabledContinueButtonStyle}>
             {
               locationLoading ?
                 <MySpinner color={WHITE}/> :
                 <img src={rightArrowWhite}
-                     style={rightArrowStyle}
-                     alt={'location-button-icon'}
-                     width={32}
-                     height={32}
+                  style={rightArrowStyle}
+                  alt={'location-button-icon'}
+                  width={32}
+                  height={32}
                 />
             }
           </div>
         </div>
       </div>
       <div className={'speedtest--opaque-hoverable'}
-           style={useCurrentLocationStyle}
-           onClick={triggerAutoLocation}
+        style={useCurrentLocationStyle}
+        onClick={triggerAutoLocation}
       >
         <img src={LocationButtonSmall}
-             width={14}
-             height={14}
-             alt={'location-button-icon-small'}
-             style={smallIconStyle}
-         />
+          width={14}
+          height={14}
+          alt={'location-button-icon-small'}
+          style={smallIconStyle}
+        />
         <p className={'speedtest--p speedtest--bold'} style={useLocationStyle}>Use my current location</p>
       </div>
       { error && <p className={'speedtest--p'} style={errorMessageStyle}>{parseError(error)}</p> }
       <LocationSuggestionsList suggestions={suggestions}
-                               autofillInput={autofillInput}
-                               open={suggestionsListOpen}
-                               setOpen={setSuggestionsListOpen}
-                               currentInputValue={userData.address.address}
+        autofillInput={autofillInput}
+        open={suggestionsListOpen}
+        setOpen={setSuggestionsListOpen}
+        currentInputValue={userData.address.address}
       />
     </div>
   )

--- a/speedtest/src/components/StepsPage/Pages/LocationSearchStep/LocationSearchStepPage.jsx
+++ b/speedtest/src/components/StepsPage/Pages/LocationSearchStep/LocationSearchStepPage.jsx
@@ -8,7 +8,7 @@ import SuggestionsModal from "./SuggestionsModal";
 import {MyBackButton} from "../../../common/MyBackButton";
 import iconLeftArrow from '../../../../assets/icons-left-arrow.png';
 import {useViewportSizes} from "../../../../hooks/useViewportSizes";
-import UserDataContext from "../../../../context/UserData";
+import emptyAddress from "../../../../../context/UserData";
 
 const locationSearchStepStyle = {
   width: '100%',
@@ -73,6 +73,18 @@ const LocationSearchStepPage = ({
     setIsModalOpen(true);
   }
 
+  const onConfirmAddress = (coordinates) => {
+    if(coordinates) {
+      confirmAddress(coordinates);
+    } else {
+      const addressInputElement = document.getElementById('speedtest--address-input');
+      if (addressInputElement) {
+        addressInputElement.value = null;
+        setAddress(emptyAddress);
+      }
+    }
+  }
+
   const closeSuggestionsModal = () => setIsSuggestionsModalOpen(false);
 
   return (
@@ -82,6 +94,7 @@ const LocationSearchStepPage = ({
       <MyAddressInput handleContinue={handleContinue}
                       setGeolocationError={setGeolocationError}
                       openGenericLocationModal={openGenericLocationModal}
+                      openCurrentLocationModal={setIsModalOpen}
                       confirmedAddress={confirmedAddress}
                       setSelectedSuggestion={setSelectedSuggestion}
                       openSuggestionsModal={openSuggestionsModal}
@@ -92,13 +105,13 @@ const LocationSearchStepPage = ({
       { error && <MyMessageSnackbar type={'error'} message={error}/> }
       <MyMapModal isOpen={isModalOpen}
                   setIsOpen={setIsModalOpen}
-                  confirmAddress={confirmAddress}
+                  confirmAddress={onConfirmAddress}
                   setAddress={setAddress}
                   goToNextPage={goToNextPage}
       />
       <MyMapModal isOpen={isGenericLocationModalOpen}
                   setIsOpen={setIsGenericLocationModalOpen}
-                  confirmAddress={confirmAddress}
+                  confirmAddress={onConfirmAddress}
                   address={null}
                   isGeneric
                   setAddress={setAddress}


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [Update location picking step given new design](https://linear.app/exactly/issue/TTAC-1196/update-location-picking-step-given-new-design)
* [Reconcile the requirements & designs](https://linear.app/exactly/issue/TTAC-1821/implementation-of-update-to-location-picking-step)
* [Clicking on "Use my current location" and having access to the browser location, should open "Confirm your location" modal.](https://linear.app/exactly/issue/TTAC-1829/clicking-on-use-my-current-location-and-having-access-to-the-browser)
* [When opening "Tell us your location" modal, handle the zoom level according to the zip code](https://linear.app/exactly/issue/TTAC-1830/when-opening-tell-us-your-location-modal-handle-the-zoom-level)

Completes TTAC-1196, TTAC-1820, TTAC-1821, TTAC-1829 and TTAC-1830.

## Covering the following changes:
- Features:
    - Location picking step updated