### PR TITLE
smtp host modified to new url

### DIFF
--- a/server/config/environments/production.rb
+++ b/server/config/environments/production.rb
@@ -69,14 +69,14 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     address:              'smtp.postmarkapp.com',
     port:                 587,
-    domain:               'radar.exactlylabs.com',
+    domain:               'pods.radartoolkit.com',
     user_name:            ENV["SMTP_PASSWORD"],
     password:             ENV["SMTP_PASSWORD"],
     authentication:       'plain',
     enable_starttls_auto: true
   }
   config.action_mailer.default_url_options = {
-    host: 'radar.exactlylabs.com',
+    host: 'pods.radartoolkit.com',
     protocol: 'https'
   }
 


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC-1875 - Staging is not sending emails](https://linear.app/exactly/issue/TTAC-1875/staging-is-not-sending-emails)
* [TTAC-1968 - Move SMTP configuration to new hostname](https://linear.app/exactly/issue/TTAC-1986/move-smtp-configuration-to-new-hostname)

Completes TTAC-1875 and TTAC-1968.

## Covering the following changes:
- Bugs Fixed:
    - SMTP configuration was using old hostname. Moved to `pods.radartoolkit.com`
