### PR TITLE
removed average calculation from every measurement processed

### DIFF
--- a/server/app/jobs/process_measurement_job.rb
+++ b/server/app/jobs/process_measurement_job.rb
@@ -32,7 +32,7 @@ class ProcessMeasurementJob < ApplicationJob
       measurement.upload = result["Upload"]["Value"]
       measurement.latency = result["MinRTT"]["Value"]
       measurement.extended_info = extended_info
-      
+
     when "OOKLA"
       result = JSON.parse(measurement.result.download)
 
@@ -42,7 +42,7 @@ class ProcessMeasurementJob < ApplicationJob
       measurement.jitter = result["ping"]["jitter"]
       measurement.download_total_bytes = result["download"]["bytes"] * 1.1 # From tests, it seems that the real value is 3-10% of what the test returns
       measurement.upload_total_bytes = result["upload"]["bytes"] * 1.1 # From tests, it seems that the real value is 5-10% of what the test returns
-  
+
     end
     measurement.processed = true
     measurement.processed_at = measurement.processed_at ? measurement.processed_at : Time.now
@@ -50,12 +50,12 @@ class ProcessMeasurementJob < ApplicationJob
     measurement.upload_total_bytes = 0 if measurement.upload_total_bytes.nil?
     measurement.save
     measurement.client.add_bytes!(measurement.created_at, measurement.download_total_bytes + measurement.upload_total_bytes)
-  
+
     if measurement.location.present?
-      measurement.location.recalculate_averages!
+      measurement.location.process_new_measurement!(measurement)
     end
     if measurement.client.present?
-      measurement.client.recalculate_averages!
+      measurement.client.process_new_measurement!(measurement)
     end
   end
 end

--- a/server/app/models/client.rb
+++ b/server/app/models/client.rb
@@ -644,16 +644,44 @@ class Client < ApplicationRecord
     update(test_requested: true)
   end
 
+  def process_new_measurement!(measurement)
+    query = %{
+      UPDATE clients SET
+        measurements_count = measurements_count + 1,
+        measurements_download_sum = measurements_download_sum + :download,
+        measurements_upload_sum = measurements_upload_sum + :upload,
+        download_avg = (measurements_download_sum + :download) / (measurements_count + 1),
+        upload_avg = (measurements_upload_sum + :upload) / (measurements_count + 1)
+      WHERE id = :client_id
+    }
+    ActiveRecord::Base.connection.execute(
+      ApplicationRecord.sanitize_sql([query, {
+        download: measurement.download,
+        upload: measurement.upload,
+        client_id: self.id
+      }])
+    )
+  end
+
   def recalculate_averages!
     if self.location.nil? || self.account.nil?
       self.download_avg = nil
       self.upload_avg = nil
     else
+      model = Measurement.arel_table
       measurements = self.measurements.where(location_id: self.location.id, account_id: self.account.id)
-      if measurements.count > 0
-        self.download_avg = measurements.average(:download).round(3)
-        self.upload_avg = measurements.average(:upload).round(3)
+      count, download, upload = measurements.pluck(model[:id].count, model[:download].sum, model[:upload].sum).first
+      if count > 0
+        self.lock!
+        self.measurements_count = count
+        self.measurements_download_sum = download
+        self.measurements_upload_sum = upload
+        self.download_avg = (self.measurements_download_sum / self.measurements_count).round(3)
+        self.upload_avg = (self.measurements_upload_sum / self.measurements_count).round(3)
       else
+        self.measurements_count = 0
+        self.measurements_download_sum = 0
+        self.measurements_upload_sum = 0
         self.download_avg = nil
         self.upload_avg = nil
       end

--- a/server/db/migrate/20231010142650_add_measurements_count_to_models.rb
+++ b/server/db/migrate/20231010142650_add_measurements_count_to_models.rb
@@ -1,0 +1,12 @@
+class AddMeasurementsCountToModels < ActiveRecord::Migration[6.1]
+  def change
+    add_column :locations, :measurements_count, :bigint, default: 0
+    add_column :locations, :measurements_download_sum, :float, default: 0
+    add_column :locations, :measurements_upload_sum, :float, default: 0
+
+    add_column :clients, :measurements_count, :bigint, default: 0
+    add_column :clients, :measurements_download_sum, :float, default: 0
+    add_column :clients, :measurements_upload_sum, :float, default: 0
+
+  end
+end

--- a/server/db/schema.rb
+++ b/server/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_29_105840) do
+ActiveRecord::Schema.define(version: 2023_10_10_142650) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pageinspect"
@@ -204,7 +204,6 @@ ActiveRecord::Schema.define(version: 2023_09_29_105840) do
     t.float "speed_before"
     t.float "speed_accuracy_before"
     t.string "session_id"
-    t.index ["lonlat"], name: "client_speed_tests_gist_lonlat", using: :gist
     t.index ["lonlat"], name: "index_client_speed_tests_on_lonlat"
   end
 
@@ -264,6 +263,9 @@ ActiveRecord::Schema.define(version: 2023_09_29_105840) do
     t.boolean "has_watchdog", default: false
     t.float "download_avg"
     t.float "upload_avg"
+    t.bigint "measurements_count", default: 0
+    t.float "measurements_download_sum", default: 0.0
+    t.float "measurements_upload_sum", default: 0.0
     t.index ["autonomous_system_id"], name: "index_clients_on_autonomous_system_id"
     t.index ["claimed_by_id"], name: "index_clients_on_claimed_by_id"
     t.index ["client_version_id"], name: "index_clients_on_client_version_id"
@@ -327,7 +329,6 @@ ActiveRecord::Schema.define(version: 2023_09_29_105840) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "study_geospace", default: false
-    t.index "st_setsrid(geom, 4326)", name: "geospaces_gist_geom", using: :gist
     t.index "st_setsrid(geom, 4326)", name: "index_geospaces_on_st_setsrid_geom_4326", using: :gist
   end
 
@@ -387,6 +388,9 @@ ActiveRecord::Schema.define(version: 2023_09_29_105840) do
     t.datetime "offline_since"
     t.boolean "online", default: false
     t.boolean "notified_when_online", default: false
+    t.bigint "measurements_count", default: 0
+    t.float "measurements_download_sum", default: 0.0
+    t.float "measurements_upload_sum", default: 0.0
     t.index ["account_id"], name: "index_locations_on_account_id"
     t.index ["account_id"], name: "test_locations_on_account_id"
     t.index ["created_by_id"], name: "index_locations_on_created_by_id"
@@ -450,6 +454,7 @@ ActiveRecord::Schema.define(version: 2023_09_29_105840) do
     t.index ["autonomous_system_org_id"], name: "index_metrics_projections_on_autonomous_system_org_id"
     t.index ["parent_aggregate_id"], name: "index_metrics_projections_on_parent_aggregate_id"
     t.index ["study_aggregate_id", "autonomous_system_org_id", "bucket_name", "timestamp"], name: "metrics_projections_agg_asn_bucket_timestamp_desc_idx", order: { timestamp: :desc }
+    t.index ["study_aggregate_id", "bucket_name", "timestamp"], name: "metrics_projections_agg_bucket_timestamp_desc_idx", order: { timestamp: :desc }
     t.index ["study_aggregate_id", "timestamp"], name: "metrics_projections_agg_timestamp_desc_idx", order: { timestamp: :desc }
     t.index ["study_aggregate_id"], name: "index_metrics_projections_on_study_aggregate_id"
   end
@@ -495,33 +500,6 @@ ActiveRecord::Schema.define(version: 2023_09_29_105840) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["client_version_id"], name: "index_packages_on_client_version_id"
-  end
-
-  create_table "projections_tmp", id: false, force: :cascade do |t|
-    t.bigint "id"
-    t.datetime "timestamp"
-    t.bigint "parent_aggregate_id"
-    t.bigint "study_aggregate_id"
-    t.bigint "autonomous_system_org_id"
-    t.bigint "location_id"
-    t.bigint "event_id"
-    t.bigint "measurement_id"
-    t.bigint "client_speed_test_id"
-    t.geography "lonlat", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
-    t.string "level"
-    t.integer "online_count"
-    t.integer "incr"
-    t.boolean "location_online"
-    t.integer "location_online_incr"
-    t.integer "measurement_count"
-    t.integer "measurement_incr"
-    t.integer "points_with_tests_count"
-    t.integer "points_with_tests_incr"
-    t.integer "days_online_count"
-    t.integer "completed_locations_count"
-    t.integer "completed_locations_incr"
-    t.boolean "location_completed"
-    t.string "metric_type"
   end
 
   create_table "recent_searches", force: :cascade do |t|

--- a/server/pending_seed_runner.sh
+++ b/server/pending_seed_runner.sh
@@ -6,3 +6,5 @@
 # This script must be run from the root directory.
 # Whenever we add a new seed file, we need this file to get updated as well
 
+rails runner db/custom_seeds/seed_fill_location_measurements_avg.rb
+rails runner db/custom_seeds/seed_fill_pod_measurements_avg.rb


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC-2014 - Remove call of measurements.count for every new measurement processed](https://linear.app/exactly/issue/TTAC-2014/remove-call-of-measurementscount-for-every-new-measurement-processed)

Completes TTAC-2014.

## Covering the following changes:
- Bugs Fixed:
    - DB performance improvement by modifying how we compute averages on every newly processed measurement
