### PR TITLE
Map failing on Production version of the Andriod speed test app

### DIFF
--- a/speedtest_mobile/client_mobile_app/lib/core/flavors/string_resource/string_resource_prod.dart
+++ b/speedtest_mobile/client_mobile_app/lib/core/flavors/string_resource/string_resource_prod.dart
@@ -19,7 +19,7 @@ class StringResourceProd implements IStringResource {
 
   @override
   String WEB_ENDPOINT =
-      'https://speed.radartoolkit/?webviewMode=true&tab=2&noZoomControl=true&global=true&client_id=1';
+      'https://speed.radartoolkit.com/?webviewMode=true&tab=2&noZoomControl=true&global=true&client_id=1';
 
   @override
   String WEB_ENDPOINT_COOKIE_DOMAIN = 'speed.radartoolkit.com';


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [Map failing on Production version of the Andriod speed test app](https://linear.app/exactly/issue/TTAC-2081/map-failing-on-production-version-of-the-andriod-speed-test-app)

Completes TTAC-2081.

## Covering the following changes:
- Bugs Fixed:
    - wrong web-view endpoint used on production.