### PR TITLE
location online alerts will now trigger only when in a study county

### DIFF
--- a/server/app/jobs/location_notification_jobs.rb
+++ b/server/app/jobs/location_notification_jobs.rb
@@ -59,7 +59,7 @@ module LocationNotificationJobs
       EventsNotifier.notify_location_online(location_info) unless location.notified_when_online?
       location.update(notified_when_online: true)
 
-      return unless location_info&.state&.study_geospace?
+      return unless location_info&.county&.study_geospace?
 
       county_goal = location_info&.county.study_aggregate_by_level('county')&.locations_goal || Location::LOCATIONS_PER_COUNTY_GOAL
       place_goal = location_info&.place.study_aggregate_by_level('census_place')&.locations_goal || Location::LOCATIONS_PER_PLACE_GOAL


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC-2105 - Silence non-study area alerts](https://linear.app/exactly/issue/TTAC-2105/silence-non-study-area-alerts)

Completes TTAC-2105.

## Covering the following changes:
- Bugs Fixed:
    - Location online alerts will only trigger when in a study county.

