### PR TITLE
Silenced a sentry error that has no fix

### DIFF
--- a/pods_agent/services/sysinfo/sysinfomanager.go
+++ b/pods_agent/services/sysinfo/sysinfomanager.go
@@ -212,6 +212,10 @@ func (si SysInfoManager) GetSysTimezone() (*time.Location, error) {
 
 	out, err := si.runCommand(exec.Command("timedatectl", "--value", "-p", "Timezone", "show"))
 	if err != nil {
+		metadata := errors.GetMetadata(err)
+		if metadata != nil && strings.Contains((*metadata)["stderr"].(string), "Connection timed out") {
+			return nil, nil
+		}
 		return nil, errors.W(err)
 	}
 	locStr := strings.Trim(strings.TrimSpace(string(out)), "\n")

--- a/pods_agent/watchdog/scanner.go
+++ b/pods_agent/watchdog/scanner.go
@@ -108,7 +108,7 @@ func ScanSystem(c *config.Config, sysManager SystemManager) (bool, error) {
 	if err != nil {
 		return false, errors.W(err)
 	}
-	if tz.String() != "UTC" {
+	if tz != nil && tz.String() != "UTC" {
 		if err := sysManager.SetSysTimezone(utc); err != nil {
 			return false, errors.W(err)
 		}

--- a/pods_agent/watchdog/scanner_test.go
+++ b/pods_agent/watchdog/scanner_test.go
@@ -196,3 +196,24 @@ func TestScanSystemTimeZoneChanged(t *testing.T) {
 		t.Fatalf("ScanSystem didn't return that it has changed")
 	}
 }
+
+func TestScanSystemTimeZoneReturnedNilNoChange(t *testing.T) {
+	m := mocks.NewSystemManager(t)
+	m.On("GetHostname").Return("1234", nil)
+	m.On("GetRCLocal").Return(mustReadFile("osfiles/etc/rc.local"), nil)
+	m.On("GetBootConfig").Return(mustReadFile("osfiles/boot/config.txt"), nil)
+	m.On("GetCMDLine").Return(mustReadFile("osfiles/boot/cmdline.txt"), nil)
+	m.On("GetLogindConf").Return(mustReadFile("osfiles/etc/systemd/logind.conf"), nil)
+	m.On("GetWatchdogServiceFile").Return(mustReadFile("osfiles/etc/systemd/system/podwatchdog@.service"), nil)
+	m.On("GetSysTimezone").Return(nil, nil)
+	m.On("GetAuthLogFile").Return([]byte(""), nil)
+	c := &config.Config{}
+	c.ClientId = "1234"
+	hasChanged, err := ScanSystem(c, m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasChanged {
+		t.Fatalf("ScanSystem expected to not have changes")
+	}
+}


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC-2137](https://linear.app/exactly/issue/TTAC-2137/error-treatment-for-timectl-failure)

Completes TTAC-2137.

## Covering the following changes:
- Bugs Fixed:
    - Removed alert for an OS error that we don't have control over
