### PR TITLE
Hotfix for wrong account on edit location

### DIFF
--- a/server/app/views/locations/_form.html.erb
+++ b/server/app/views/locations/_form.html.erb
@@ -59,7 +59,7 @@
                     tabindex="-1"
             >
               <% policy_scope(Account).each_with_index do |account, index|%>
-                <%= render partial: "clients/client_select_option", locals: { option: account, selected: index === 0} %>
+                <%= render partial: "clients/client_select_option", locals: { option: account, selected: location.account.present? ? location.account.id === account.id : index === 0} %>
               <% end %> 
             </select>
           </div>


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [Pod Dashboard: Pod is Assigned to a different account than the location](https://linear.app/exactly/issue/TTAC-2198/pod-dashboard-pod-is-assigned-to-a-different-account-than-the-location)

Completes TTAC-2198.

## Covering the following changes:
- Bugs Fixed:
    - Fixed location edit modal showing always the first account instead of the entity's one.