### PR TITLE
Custom number of Dots for Tests within bounds api

### DIFF
--- a/server/app/controllers/client_api/v1/api_controller.rb
+++ b/server/app/controllers/client_api/v1/api_controller.rb
@@ -16,7 +16,7 @@ module ClientApi
 
       def check_allowed_origin
         @allowed = true
-        if request.origin && !@widget_client.client_urls.include?(request.origin) # Just check for origin if present, else, skip
+        if Rails.env.production? && request.origin && !@widget_client.client_urls.include?(request.origin) # Just check for origin if present, else, skip
           @allowed = false
         end
       end

--- a/server/app/controllers/client_api/v1/speed_tests_controller.rb
+++ b/server/app/controllers/client_api/v1/speed_tests_controller.rb
@@ -32,6 +32,7 @@ module ClientApi
       # we can respond with tests inside that bounding box
       def tests_with_bounds
         is_global = params[:global]
+        dots = (params[:dots] || 1500).to_i
         sw_lat = params[:sw_lat]
         sw_lng = params[:sw_lng]
         ne_lat = params[:ne_lat]
@@ -63,7 +64,7 @@ module ClientApi
           if !is_global
             sql += " AND tested_by = #{@widget_client.id}"
           end
-          sql += " ORDER BY tested_at DESC LIMIT 500 "
+          sql += " ORDER BY tested_at DESC LIMIT #{dots} "
           @speed_tests = ActiveRecord::Base.connection.execute(sql)
         end
         respond_to do |format|


### PR DESCRIPTION
The API now allows for customized number of dots in an attempt to help adjusting it when rendering in the UI.


## This PR includes the following Linear tasks:
* [TTAC-2183 - Speed Test Map Not Loading](https://linear.app/exactly/issue/TTAC-2183/speed-test-map-not-loading)

## Covering the following changes:
- Other:
    - Speed Tests results API for filling dots in Map in speed.radartoolkit.com has a default of 1500 dots and allows for a custom number.
