### PR TITLE
server public form submissions notified through discord

### DIFF
--- a/server/app/mailers/public_submission_mailer.rb
+++ b/server/app/mailers/public_submission_mailer.rb
@@ -2,5 +2,6 @@ class PublicSubmissionMailer < ApplicationMailer
   def new_submission
     @submission = params[:submission]
     mail(to: ENV['PUBLIC_PAGE_SUBMISSION_EMAILS'].split(","), subject: 'New public page submission')
+    EventsNotifier.notify_public_page_submission(@submission)
   end
 end

--- a/server/lib/events_notifier/discord_notifier.rb
+++ b/server/lib/events_notifier/discord_notifier.rb
@@ -151,6 +151,37 @@ class DiscordNotifier < EventsNotifier::Notifier
     end
   end
 
+  def notify_public_page_submission(submission)
+    @client.execute do |builder|
+      builder.add_embed do |embed|
+        embed.title = ":new: == New Public Page Submission == :new:"
+        embed.description = "A new user has just submitted a form in the public page"
+        embed.timestamp = Time.now
+        embed.color = 0x23C552
+        add_fieldset embed, "Contact Information" do |fieldset|
+          fieldset.add_field(name: "First Name", value: submission.first_name)
+          fieldset.add_field(name: "Last Name", value: submission.last_name)
+          fieldset.add_field(name: "E-Mail", value: submission.email)
+          fieldset.add_field(name: "Phone Number", value: submission.phone_number)
+        end
+        add_fieldset embed, "Location Information" do |fieldset|
+          fieldset.add_field(name: "State", value: submission.state)
+          fieldset.add_field(name: "County", value: submission.county)
+          fieldset.add_field(name: "Consumer Type", value: submission.consumer_type)
+          fieldset.add_field(name: "Business Name", value: submission.business_name)
+        end
+        add_fieldset embed, "Connection Information" do |fieldset|
+          fieldset.add_field(name: "ISP", value: submission.isp)
+          fieldset.add_field(name: "Connection Type", value: submission.connection_type)
+          fieldset.add_field(name: "Download Speed", value: submission.download_speed)
+          fieldset.add_field(name: "Upload Speed", value: submission.upload_speed)
+          fieldset.add_field(name: "Connection Placement", value: submission.connection_placement)
+          fieldset.add_field(name: "Service Satisfaction", value: submission.service_satisfaction)
+        end
+      end
+    end
+  end
+
   private
 
   def fill_default_location_info(location_info, fieldset)

--- a/server/lib/events_notifier/local_notifier.rb
+++ b/server/lib/events_notifier/local_notifier.rb
@@ -4,7 +4,7 @@ class LocalNotifier < EventsNotifier::Notifier
   def notify_new_account(account, contact)
     puts %{
       New Account created
-        
+
         * Account Name: #{account.name}
         * Account Type: #{account.account_type.titleize}
         * Contact Name: #{contact.first_name} #{contact.last_name}
@@ -21,7 +21,7 @@ class LocalNotifier < EventsNotifier::Notifier
     }
   end
 
-  
+
 
   def notify_new_location(location_info)
     puts %{
@@ -65,6 +65,26 @@ class LocalNotifier < EventsNotifier::Notifier
       * Location Place: #{location_info&.place&.name}
       * Location Study State?: #{location_info.location.study_state?}
       * Location Extras: #{location_info&.extra}
+    }
+  end
+
+  def notify_public_page_submission(submission)
+    puts %{
+      New Public Page Submission!
+      * First Name: #{submission.first_name}
+      * Last Name: #{submission.last_name}
+      * Email: #{submission.email}
+      * Phone Number: #{submission.phone_number}
+      * State: #{submission.state}
+      * County: #{submission.county}
+      * Consumer Type: #{submission.consumer_type}
+      * Business Name: #{submission.business_name}
+      * ISP: #{submission.isp}
+      * Connection Type: #{submission.connection_type}
+      * Download Speed: #{submission.download_speed}
+      * Upload Speed: #{submission.upload_speed}
+      * Connection Placement: #{submission.connection_placement}
+      * Service Satisfaction: #{submission.service_satisfaction}
     }
   end
 end

--- a/server/lib/events_notifier/notifier.rb
+++ b/server/lib/events_notifier/notifier.rb
@@ -75,11 +75,16 @@ module EventsNotifier
       notifier.notify_location_offline(location_info)
     end
   end
-  
+
   def self.notify_study_goal_reached(geospace, goal, as_org=nil)
     @notifiers.each do |notifier|
       notifier.notify_study_goal_reached(geospace, goal, as_org)
     end
   end
 
+  def self.notify_public_page_submission(submission)
+    @notifiers.each do |notifier|
+      notifier.notify_public_page_submission(submission)
+    end
+  end
 end


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC-2217 - Add submissions from the Public Page to Discord](https://linear.app/exactly/issue/TTAC-2217/add-submissions-from-the-public-page-to-discord)

Completes TTAC-2217.

## Covering the following changes:
- Features:
    - Discord notifications of Public Page form submissions.
