### PR TITLE
Setting initial values when running a new speed test

### DIFF
--- a/speedtest_mobile/client_mobile_app/lib/core/background_fetch/background_speed_test.dart
+++ b/speedtest_mobile/client_mobile_app/lib/core/background_fetch/background_speed_test.dart
@@ -40,6 +40,7 @@ class BackgroundSpeedTest {
       (isTestingDownloadSpeed: false, isTestingUploadSpeed: false);
 
   Future<void> startSpeedTest() async {
+    setInitialValues();
     _positionBeforeSpeedTest = await _getPosition();
     if (_positionBeforeSpeedTest == null) return;
     _packageInfo = await PackageInfo.fromPlatform();
@@ -202,5 +203,13 @@ class BackgroundSpeedTest {
       'connection_data': _connectionInfo?.toJson(),
       'timestamp': DateTime.now().toUtc().toIso8601String(),
     };
+  }
+
+  void setInitialValues() {
+    _responses = [];
+    _sessionId = null;
+    _connectionInfo = null;
+    _positionAfterSpeedTest = null;
+    _positionBeforeSpeedTest = null;
   }
 }


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [Missing to reset speed test extra fields](https://linear.app/exactly/issue/TTAC-2230/missing-to-reset-speed-test-extra-fields)

Completes TTAC-2230

## Covering the following changes:
- Bugs Fixed:
    -  Some fields were not reset at the end of a speed test.