### PR TITLE
New periodic call to unlock pods test request

### DIFF
--- a/server/app/models/client.rb
+++ b/server/app/models/client.rb
@@ -189,6 +189,13 @@ class Client < ApplicationRecord
     end
   end
 
+  def self.resend_missed_test_requests!
+    # Search for online Clients, with a test_requested set to true and whose test_scheduled_at is older than 10 minutes
+    Client.where_online.where(test_requested: true).where('test_scheduled_at < ?', 10.minutes.ago).each do |client|
+      PodAgentChannel.broadcast_test_requested client
+    end
+  end
+
   def send_event
     if saved_change_to_online || saved_change_to_test_requested
       PodStatusChannel.broadcast_to(CHANNELS[:clients_status], self)

--- a/server/clock.rb
+++ b/server/clock.rb
@@ -7,6 +7,7 @@ scheduler.every '5s', overlap: false do
     if Rails.application.healthy? && !Rails.application.transient?
       Client.update_outdated_online!
       Location.update_online_status!
+      Client.resend_missed_test_requests!
     end
   rescue => e
     Sentry.capture_exception(e)


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC-2274 - Pod Stuck in "Test Running State"](https://linear.app/exactly/issue/TTAC-2274/pod-stuck-in-test-running-state)

Completes TTAC-2274.

## Covering the following changes:

- Bugs Fixed:
    - Added a new routine that searches for pods with pending speed test requests older than 10 minutes and re-requests the test.
