### PR TITLE
Deactivated In Service concept

### DIFF
--- a/server/app/models/client.rb
+++ b/server/app/models/client.rb
@@ -69,7 +69,7 @@ class Client < ApplicationRecord
   }
   scope :where_test_should_be_requested, lambda {
     where(%{
-      (test_scheduled_at <= NOW() AT TIME ZONE COALESCE(test_allowed_time_tz, 'UTC') OR test_scheduled_at IS NULL) AND (test_requested = false AND in_service = true)
+      (test_scheduled_at <= NOW() AT TIME ZONE COALESCE(test_allowed_time_tz, 'UTC') OR test_scheduled_at IS NULL) AND test_requested = false
       AND (
         (test_allowed_time_end IS NULL AND test_allowed_time_start IS NULL)
         OR (

--- a/server/db/custom_seeds/seed_fill_in_service.rb
+++ b/server/db/custom_seeds/seed_fill_in_service.rb
@@ -1,0 +1,1 @@
+Client.update(in_service: true)

--- a/server/db/migrate/20240229184911_set_inservice_default_to_true.rb
+++ b/server/db/migrate/20240229184911_set_inservice_default_to_true.rb
@@ -1,0 +1,5 @@
+class SetInserviceDefaultToTrue < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :clients, :in_service, true
+  end
+end

--- a/server/pending_seed_runner.sh
+++ b/server/pending_seed_runner.sh
@@ -6,6 +6,4 @@
 # This script must be run from the root directory.
 # Whenever we add a new seed file, we need this file to get updated as well
 
-rails runner db/custom_seeds/seed_fill_geospaces.rb
-rails runner db/custom_seeds/seed_fill_extended_area.rb
-rails runner db/custom_seeds/seed_fill_location_geospace_links.rb
+rails runner db/custom_seeds/seed_fill_in_service.rb


### PR DESCRIPTION
This PR removes the need for a pod to be in service to request speed tests. Additionally, it changes the default value to True and includes a seed to set existing pods' in_service flags to True.


## This PR includes the following Linear tasks:
* [TTAC-2259 - Make In Service not mean anything](https://linear.app/exactly/issue/TTAC-2259/make-in-service-not-mean-anything)

Completes TTAC-2259.

## Covering the following changes:
- Other:
    - Removed the need for a pod to be "In Service" to have speed tests run. All pods have it true by default.
