### PR TITLE
Quick fixes for networks and datetime

### DIFF
--- a/server/app/helpers/tables_helper.rb
+++ b/server/app/helpers/tables_helper.rb
@@ -129,7 +129,7 @@ module TablesHelper
     when TableTypes::MEASUREMENTS
       rows = [
         *rows,
-        { text: 'Time' },
+        { text: 'Time', partial_after: "application/timezone_tooltip" },
         { text: 'Type' },
         { text: 'Download', icon_before: 'download-icon.png' },
         { text: 'Upload', icon_before: 'upload-icon.png' },

--- a/server/app/views/application/components/sidebar/_search_results.html.erb
+++ b/server/app/views/application/components/sidebar/_search_results.html.erb
@@ -15,7 +15,13 @@
     <div class="sidebar--horizontal-divider"></div>
   <% end %>
   <% if results[:locations].count > 0 %>
-    <p class="help-text m-0 ms-2 mb-2">Locations</p>
+    <p class="help-text m-0 ms-2 mb-2">
+      <% if FeatureFlagHelper.is_available('networks', current_user) %>
+        Networks
+      <% else %>
+        Locations
+      <% end %>
+    </p>
     <div class="sidebar--recents-container">
       <% results[:locations].each do |location| %>
         <%= render partial: "application/components/sidebar/result_item",

--- a/server/app/views/application/components/tables/_table_titles.html.erb
+++ b/server/app/views/application/components/tables/_table_titles.html.erb
@@ -14,6 +14,9 @@
       <% if title[:sort] %>
         <%= image_tag image_url(current_sort_order_icon_name), width: 16, height: 16 %>
       <% end %>
+      <% if title[:partial_after] %>
+        <%= render partial: title[:partial_after] %>
+      <% end %>
       <% if title[:text] == 'Checkbox' %>
         <div class="form-check form-check-sm form-check-custom form-check-solid tables--checkbox-container" >
           <input id="check-box-select-all"

--- a/server/app/views/location_clients/index.html.erb
+++ b/server/app/views/location_clients/index.html.erb
@@ -12,7 +12,13 @@
         <li class="breadcrumb-item page-sub-title"><%= current_account.name %>
           <!--<a href="/craft/index.html" class="text-muted text-hover-primary">Home</a>-->
         </li>
-        <li class="breadcrumb-item page-sub-title">Locations</li>
+        <li class="breadcrumb-item page-sub-title">
+          <% if FeatureFlagHelper.is_available('networks', current_user) %>
+            Networks
+          <% else %>
+            Locations
+          <% end %>
+        </li>
       </ul>
       <!--end::Breadcrumb-->
     </div>

--- a/server/app/views/location_measurements/index.html.erb
+++ b/server/app/views/location_measurements/index.html.erb
@@ -12,7 +12,13 @@
         <li class="breadcrumb-item page-sub-title"><%= current_account.name %>
           <!--<a href="/craft/index.html" class="text-muted text-hover-primary">Home</a>-->
         </li>
-        <li class="breadcrumb-item page-sub-title">Locations</li>
+        <li class="breadcrumb-item page-sub-title">
+          <% if FeatureFlagHelper.is_available('networks', current_user) %>
+            Networks
+          <% else %>
+            Locations
+          <% end %>
+        </li>
       </ul>
       <!--end::Breadcrumb-->
     </div>

--- a/server/app/views/measurements/modals/show/_details_modal.html.erb
+++ b/server/app/views/measurements/modals/show/_details_modal.html.erb
@@ -25,7 +25,7 @@
     </div>
     <div class="row d-flex flex-row mb-1">
       <p class="forms--label w-25">Date/Time</p>
-      <p class="regular-text w-75" data-controller="localtime"><%= @measurement.created_at %></p>
+      <p class="regular-text w-75"><%= pretty_print_date_with_time(@measurement.created_at) %></p>
     </div>
     <div class="row d-flex flex-row mb-1">
       <p class="forms--label w-25">Download</p>


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [Date stamp is ahead a day in the Radar Dashboard Measurements pane](https://linear.app/exactly/issue/TTAC-2350/date-stamp-is-ahead-a-day-in-the-radar-dashboard-measurements-pane)

Completes TTAC-2350.

## Covering the following changes:
- Bugs Fixed:
    - Fixed some titles/labels referring to "Locations" instead of "Networks"
    - Checked date/time stamps on measurements were correct
