### PR TITLE
Fixed missing networks controllers

### DIFF
--- a/server/app/views/networks/modals/create/_create_modal.html.erb
+++ b/server/app/views/networks/modals/create/_create_modal.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "application/components/modals/modal_header",
     locals: { title: "Create new network", is_custom: true }
 %>
-<%= form_with model: @location, class: "networks--modal-form" do |form| %>
+<%= form_with model: @location, class: "networks--modal-form", data: { controller: "location-form" } do |form| %>
   <%= render partial: "networks/modals/shared/network_details_modal",
       locals: {
         type: "create",

--- a/server/app/views/networks/modals/create/_onboarding_create_modal.html.erb
+++ b/server/app/views/networks/modals/create/_onboarding_create_modal.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "application/components/modals/modal_header",
            locals: { title: "Create new network", is_custom: true, goes_back: true, go_back_url: onboarding_step_2_path, go_back_action: "click->onboard#goToOnboardingStep" }
 %>
-<%= form_with model: @location, class: "networks--modal-form" do |form| %>
+<%= form_with model: @location, class: "networks--modal-form", data: { controller: "location-form" }  do |form| %>
   <%= render partial: "networks/modals/shared/network_details_modal",
              locals: {
                type: "create",

--- a/server/app/views/networks/modals/edit/_edit_modal.html.erb
+++ b/server/app/views/networks/modals/edit/_edit_modal.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "application/components/modals/modal_header",
            locals: { title: "Edit network", is_custom: true }
 %>
-<%= form_with model: @location do |form| %>
+<%= form_with model: @location, data: { controller: "location-form" } do |form| %>
   <%= render partial: "networks/modals/shared/network_details_modal",
              locals: {
                type: "edit",

--- a/server/app/views/pods/components/_pod_network_creator_component.html.erb
+++ b/server/app/views/pods/components/_pod_network_creator_component.html.erb
@@ -2,7 +2,7 @@
 
 <div class="pods--create-network-component-container <%= invisible ? 'invisible' : nil %>"
   data-pod-account-and-network-target="newNetworkComponent"
-  data-controller="categories"
+  data-controller="categories location-form"
   >
   <%= render partial: "networks/modals/shared/network_details_modal",
       locals: {


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [🪳 BUG: Missing controller on network creation modal](https://linear.app/exactly/issue/TTAC-2472/%F0%9F%AA%B3-bug-missing-controller-on-network-creation-modal)

Completes TTAC-2472.

## Covering the following changes:
- Bugs Fixed:
    - Fixed missing JS controller in networks modals