### PR TITLE
add index to location and created_at for measurements to fix radar server location loading perf

### DIFF
--- a/server/db/migrate/20240504042012_add_location_and_created_at_index_to_measurements.rb
+++ b/server/db/migrate/20240504042012_add_location_and_created_at_index_to_measurements.rb
@@ -1,0 +1,5 @@
+class AddLocationAndCreatedAtIndexToMeasurements < ActiveRecord::Migration[6.1]
+  def change
+    add_index :measurements, [:location_id, :created_at], order: { created_at: :desc }
+  end
+end

--- a/server/db/schema.rb
+++ b/server/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_04_30_011256) do
+ActiveRecord::Schema.define(version: 2024_05_04_042012) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -483,6 +483,7 @@ ActiveRecord::Schema.define(version: 2024_04_30_011256) do
     t.index ["account_id"], name: "index_measurements_on_account_id"
     t.index ["autonomous_system_id"], name: "index_measurements_on_autonomous_system_id"
     t.index ["client_id"], name: "index_measurements_on_client_id"
+    t.index ["location_id", "created_at"], name: "index_measurements_on_location_id_and_created_at", order: { created_at: :desc }
     t.index ["location_id"], name: "index_measurements_on_location_id"
     t.index ["lonlat"], name: "index_measurements_on_lonlat"
     t.index ["measured_by_id"], name: "index_measurements_on_measured_by_id"
@@ -505,7 +506,6 @@ ActiveRecord::Schema.define(version: 2024_04_30_011256) do
     t.index ["autonomous_system_org_id"], name: "index_metrics_projections_on_autonomous_system_org_id"
     t.index ["parent_aggregate_id"], name: "index_metrics_projections_on_parent_aggregate_id"
     t.index ["study_aggregate_id", "autonomous_system_org_id", "bucket_name", "timestamp"], name: "metrics_projections_agg_asn_bucket_timestamp_desc_idx", order: { timestamp: :desc }
-    t.index ["study_aggregate_id", "bucket_name", "timestamp"], name: "metrics_projections_agg_bucket_timestamp_desc_idx", order: { timestamp: :desc }
     t.index ["study_aggregate_id", "timestamp"], name: "metrics_projections_agg_timestamp_desc_idx", order: { timestamp: :desc }
     t.index ["study_aggregate_id"], name: "index_metrics_projections_on_study_aggregate_id"
   end


### PR DESCRIPTION
Sorry for not using the template, but no linear task for this... just a pet peeve fixed. Adds a simple index to decrease loading time by 10-20 seconds if a location with a lot of measurements hasn't been loaded in cache recently.
