### PR TITLE
Fixes server paginator to use activerecord-isms to use offset and limit instead of Very Large Selects

### DIFF
--- a/server/app/controllers/concerns/paginator.rb
+++ b/server/app/controllers/concerns/paginator.rb
@@ -2,6 +2,6 @@ module Paginator extend ActiveSupport::Concern
   def paginate(elements, page, page_size)
     page = page.nil? ? 0 : page.to_i > 0 ? page.to_i - 1 : 0
     page_size = page_size.nil? ? 10 : page_size.to_i
-    elements.drop(page * page_size).first(page_size)
+    elements.offset(page * page_size).limit(page_size)
   end
 end


### PR DESCRIPTION
Sorry for not using the template but there's no linear ticket (or i dont know what ticket to use) for this.

This fixes the paginator to use ActiveRecord instead of ruby array methods. This means we'll use offset and limit in SQL and go wayyyyy faster on really big tables as we won't query and then serialize the full result set even though we just need a page of data (namely measurements tables should be way faster).

NOTE -- this made the assumption that all places the paginator is used today currently deals with ActiveRecord queries for "elements" and NOT ruby objects / arrays. I did a quick search that seem to show this is the case but I didn't do a close investigation to validate all the places. Please let me know if this assumption is wrong as I have not tested all code paths that use this.
