### PR TITLE
Invalid partial path on update_public_page

### DIFF
--- a/server/app/views/public_pod/update_public_page.turbo_stream.erb
+++ b/server/app/views/public_pod/update_public_page.turbo_stream.erb
@@ -1,3 +1,8 @@
 <%= turbo_stream.update "public-page-#{@client.unix_user}" do %>
-  <%= render partial: "public_pod/status_page", locals: {client: @client} %>
+  <div class="public--pod-desktop-container">
+    <%= render partial: "public_pod/variants/desktop_status_page", locals: { client: @client } %>
+  </div>
+  <div class="public--pod-responsive-container">
+    <%= render partial: "public_pod/variants/responsive_status_page", locals: { client: @client } %>
+  </div>
 <% end %>


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [🚨 EXCEPTION: Trying to render a partial with an invalid file name.](https://linear.app/exactly/issue/TTAC-2502/🚨-exception-trying-to-render-a-partial-with-an-invalid-file-name)

Completes TTAC-2502.

## Covering the following changes:
- Bugs Fixed:
    - The status page was updated but the update_public_page turbo stream was not. So it was making reference to an old and non existent partial.