### PR TITLE
Missing modal for adding pod to new network flow

### DIFF
--- a/server/app/views/locations/index.html.erb
+++ b/server/app/views/locations/index.html.erb
@@ -131,7 +131,6 @@
              locals: { turbo_frame_tag_id: "add_pod_modal", optional_added_controllers: "pod-id-step" }
   %>
 
-
   <%= render partial: "application/components/modals/turbo_modal",
              locals: { turbo_frame_tag_id: "move_networks_modal", optional_added_controllers: "multi-row-table", }
   %>


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [🚨 EXCEPTION: Missing modal for adding pod to new network flow](https://linear.app/exactly/issue/TTAC-2473/🚨-exception-missing-modal-for-adding-pod-to-new-network-flow)

Completes TTAC-2473.

## Covering the following changes:
- Bugs Fixed:
    - After creating a new network, and deciding to add a new pod, if the “Need help finding your pod ID” button is pressed, nothing happens, the corresponding modal is missing.