### PR TITLE
SocketException & Could not discover server URLs bugs fixed

### DIFF
--- a/speedtest_mobile/client_mobile_app/lib/core/web_socket_client/web_socket_client.dart
+++ b/speedtest_mobile/client_mobile_app/lib/core/web_socket_client/web_socket_client.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
@@ -22,12 +21,15 @@ class WebSocketClient {
   Map<String, StreamController<dynamic>> requests = <String, StreamController<dynamic>>{};
 
   void open() {
-    // TODO: Seperate concept of openning/closing from attempted opening/retry opening
     Uri connectEndpoint = _getConnectEndpoint(endpoint, accessToken);
 
-    socket = WebSocketChannel.connect(connectEndpoint);
-    socket!.stream
-        .listen(_handleMessages, onError: _handleError, onDone: _handleError, cancelOnError: true);
+    try {
+      socket = WebSocketChannel.connect(connectEndpoint);
+      socket!.stream.listen(_handleMessages,
+          onError: _handleError, onDone: _handleError, cancelOnError: true);
+    } catch (exception, stackTrace) {
+      Sentry.captureException(exception, stackTrace: stackTrace);
+    }
   }
 
   void close() {


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [Task](https://linear.app)
* [🚨 EXCEPTION: Bad FD in speedtest app](https://linear.app/exactly/issue/TTAC-2504/🚨-exception-bad-fd-in-speedtest-app)
* [String: Could not discover server URLs](https://linear.app/exactly/issue/TTAC-2403/string-could-not-discover-server-urls)
* [SocketException: SocketException: Failed host lookup: 'pods.staging.radartoolkit.com' (OS Error: No address associ...](https://linear.app/exactly/issue/TTAC-2340/socketexception-socketexception-failed-host-lookup)

Completes TTAC-2504, TTAC-2403 and TTAC-2340.

## Covering the following changes:
- Bugs Fixed:
    - SocketException & Could not discover server URLs bugs fixed