### PR TITLE
Fixed issues related to access control and automatic account switching

### DIFF
--- a/server/app/controllers/application_controller.rb
+++ b/server/app/controllers/application_controller.rb
@@ -114,7 +114,7 @@ class ApplicationController < ActionController::Base
   def set_all_accounts
     @auth_holder = AuthenticationHolder.new(current_user) unless @auth_holder
     @auth_holder.set_all_accounts
-    @auth_holder.set_super_user_disabled(get_super_user_disabled_value) if current_user.super_user
+    @auth_holder.set_super_user_disabled(is_super_user_disabled?) if current_user.super_user
     set_cookie(:radar_current_account_id, -1)
   end
 
@@ -137,7 +137,7 @@ class ApplicationController < ActionController::Base
         set_cookie(:radar_current_account_id, account_id)
         @auth_holder.set_user(current_user) if @auth_holder.user.nil?
         @auth_holder.set_account(Account.find(account_id))
-        @auth_holder.set_super_user_disabled(get_super_user_disabled_value) if current_user.super_user
+        @auth_holder.set_super_user_disabled(is_super_user_disabled?) if current_user.super_user
         if is_account_accessible_through_share
           @auth_holder.set_shared_account
         else
@@ -177,7 +177,7 @@ class ApplicationController < ActionController::Base
     account_id = get_cookie(:radar_current_account_id)
     begin
       @auth_holder = AuthenticationHolder.new(current_user, false, false) unless @auth_holder
-      @auth_holder.set_super_user_disabled(get_super_user_disabled_value) if current_user.super_user
+      @auth_holder.set_super_user_disabled(is_super_user_disabled?) if current_user.super_user
       if account_id
         if is_all_accounts_id(account_id)
           set_all_accounts
@@ -248,7 +248,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def get_super_user_disabled_value
+  def is_super_user_disabled?
     possible_cookie = cookies[:radar_super_user_disabled]
     return possible_cookie.present? && possible_cookie == "true"
   end

--- a/server/app/controllers/clients_controller.rb
+++ b/server/app/controllers/clients_controller.rb
@@ -850,6 +850,9 @@ class ClientsController < ApplicationController
     if @client.account_id.present?
       is_in_users_accounts = policy_scope(Account).where(id: @client.account_id).exists? # Not running find as we don't want to throw
       raise ActiveRecord::RecordNotFound.new("Couldn't find Client with 'id'=#{params[:id]}", Client.name, params[:id]) unless is_in_users_accounts
+
+      return if current_user.super_user && !is_super_user_disabled? && current_account.is_all_accounts?
+
       set_new_account(@client.account) if !current_account.is_all_accounts? && current_account.id != @client.account_id
     end
   end


### PR DESCRIPTION
Allow for users who have "indirect" access to pods/networks (currently in account A, but the resource is in account B, but the users DOES have access to account B) to go through checks in authorization, and if we need to force-change the current account, trigger that first, and then allow access. Otherwise, in the case of the user NOT being in All Accounts mode, this would throw a 404.