### PR TITLE
Quick fix for ms unit in latency chart

### DIFF
--- a/server/app/views/comparison_dashboard/latency.html.erb
+++ b/server/app/views/comparison_dashboard/latency.html.erb
@@ -10,7 +10,7 @@
             data-line-chart-data="<%= @latency.to_json %>"
             data-parent-id="compare-latency-widget<%= responsive ? '-responsive' : '' %>"
             data-y-step-size="1"
-            data-label-suffix=" s"
+            data-label-suffix=" ms"
             data-action="toggleLine@window->multi-line-chart#toggleLine"
             data-chart-id="compareLatency"
             data-is-compare-chart="true"

--- a/server/app/views/dashboard/latency.html.erb
+++ b/server/app/views/dashboard/latency.html.erb
@@ -9,7 +9,7 @@
             data-line-chart-data="<%= @latencies.to_json %>"
             data-parent-id="latency-widget<%= responsive ? '-responsive' : ''%>"
             data-y-step-size="1"
-            data-label-suffix=" s"
+            data-label-suffix=" ms"
             data-action="toggleLine@window->multi-line-chart#toggleLine"
             data-chart-id="latency"
             data-query-time-interval="<%= @query_time_interval %>"


### PR DESCRIPTION
## Covering the following changes:
- Bugs Fixed:
    - Fixed latency chart using seconds instead of ms as the unit