### PR TITLE
Removed usage of assignment that wasn't triggering model hooks

### DIFF
--- a/server/app/controllers/clients_controller.rb
+++ b/server/app/controllers/clients_controller.rb
@@ -928,7 +928,6 @@ class ClientsController < ApplicationController
       else
         @location.account = @client.account
       end
-      @location.clients << @client
       @location.save!
       @location.categories << policy_scope(Category).where(id: categories.split(",")) if categories.present?
       @client.location = @location

--- a/server/test/models/location_test.rb
+++ b/server/test/models/location_test.rb
@@ -1,11 +1,46 @@
 require "test_helper"
 
 class LocationTest < ActiveSupport::TestCase
+  setup do
+    Geocoder::Lookup::Test.set_default_stub([{
+      'coordinates'  => [40.7143528, -74.0059731],
+      'address'      => 'Somewhere',
+      'state'        => 'State',
+      'state_code'   => 'ST',
+      'country'      => 'United States',
+      'country_code' => 'US',
+      "county" => "County"
+    }])
+  end
   test "online_scope" do
     assert_equal Location.where_online.all().to_a, [locations(:online1), locations(:online2)]
   end
 
   test "offline_scope" do
     assert_equal Location.where_offline.all().to_a, [locations(:offline1), locations(:different_account)]
+  end
+
+  test "when location created with lonlat expect Reprocess Geospaces job to be called" do
+    job = lambda { |location| assert location.lonlat.present? }
+    ReprocessNetworkGeospaceJob.stub :perform_later, job do
+      Location.create!(
+        name: "Test", address: "Somewhere", lonlat: "POINT(1 1)",
+        account: accounts(:root), created_by_id: users(:user1).id
+      )
+    end
+  end
+
+  test "when location updated with lonlat kept the same, expect job to not be called" do
+    ReprocessNetworkGeospaceJob.stub :perform_later, proc { |l| raise "Should not be called" } do
+      locations(:online1).update!(name: "NewName")
+    end
+  end
+
+  test "when location updated with lonlat change, expect job to be called" do
+    mock = MiniTest::Mock.new
+    mock.expect(:call, nil, [locations(:online1)])
+    ReprocessNetworkGeospaceJob.stub :perform_later, mock do
+      locations(:online1).update!(lonlat: "POINT(40.5 1)")
+    end
   end
 end


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC-2783 - Fix some locations are still not being geocoded, and so not showing in Grafana](https://linear.app/exactly/issue/TTAC-2783/fix-some-locations-are-still-not-being-geocoded-and-so-not-showing-in)


## Covering the following changes:

- Bugs Fixed:
    - Fix error that caused some locations to not get geocoded because of hooks not getting called.
