### PR TITLE
configured mobile speedtest app's circle-ci to push to backblaze

### DIFF
--- a/speedtest_mobile/.circleci/config.yml
+++ b/speedtest_mobile/.circleci/config.yml
@@ -39,7 +39,7 @@ commands:
     steps:
       - run: curl -o b2 https://github.com/Backblaze/B2_Command_Line_Tool/releases/latest/download/b2-linux
       - run: chmod +x b2
-      - run: mv b2 /usr/bin/b2
+      - run: sudo mv b2 /usr/bin/b2
       - run: b2 account authorize ${BACKBLAZE_ACCESS_KEY} ${BACKBLAZE_SECRET_KEY}
 
 


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC-2318 - Copy Speedtest Mobile distributions to new Storage and modify CI to push new ones to it.](https://linear.app/exactly/issue/TTAC-2318/copy-speedtest-mobile-distributions-to-new-storage-and-modify-ci-to)

## Covering the following changes:
- Other:
    - Migration of mobile distributions to Backblaze bucket
