### PR TITLE
Fixes on Comparison Dashboards

### DIFF
--- a/server/app/javascript/controllers/bar_chart_controller.js
+++ b/server/app/javascript/controllers/bar_chart_controller.js
@@ -122,6 +122,10 @@ export default class BarChartController extends ChartController {
       xCoordinate = barX + barWidth + SPACING_BETWEEN_TOOLTIP_AND_BAR / 2;
     }
     
+    if(xCoordinate + tooltipWidth > this.canvasWidth) {
+      xCoordinate = this.canvasWidth - barWidth - SPACING_BETWEEN_TOOLTIP_AND_BAR / 2 - tooltipWidth;
+    }
+    
     this.ctx.roundRect(xCoordinate, yCoordinate, tooltipWidth, TOOLTIP_HEIGHT, 6);
     this.ctx.fill();
     this.ctx.stroke();

--- a/server/app/javascript/controllers/chart_controller.js
+++ b/server/app/javascript/controllers/chart_controller.js
@@ -300,8 +300,15 @@ export default class ChartController extends Controller {
   };
   
   createHiDPICanvas(w, h, ratio) {
-    // padding: 1.5rem -- 24px
-    // margin-top: 1.5rem -- 24px
+    // In comparison charts that have a right-side line toggler, we need to reduce the width of the canvas
+    // to make space for the toggler.
+    // Toggler's max-width is 140px, and we add 16px for padding
+    if(this.isCompareChart && !!this.element.dataset.togglerId) {
+      const LINE_TOGGLER_WIDTH = 140;
+      const LINE_TOGGLER_SPACING = 16;
+      w = w - LINE_TOGGLER_WIDTH - LINE_TOGGLER_SPACING;
+    }
+    
     ratio ||= this.getPixelRatio();
     this.element.width = w * ratio;
     this.element.height = h * ratio;

--- a/server/app/views/comparison_dashboard/data_usage.html.erb
+++ b/server/app/views/comparison_dashboard/data_usage.html.erb
@@ -9,7 +9,6 @@
             data-controller="multi-line-chart"
             data-line-chart-data="<%= @data_usage.to_json %>"
             data-parent-id="compare-data-usage-widget<%= responsive ? '-responsive' : '' %>"
-            data-y-step-size="100"
             data-label-suffix="<%= current_user.data_cap_unit || "GB" %>"
             data-action="toggleLine@window->multi-line-chart#toggleLine"
             data-chart-id="compareDataUsage"

--- a/server/app/views/comparison_dashboard/download_speeds.html.erb
+++ b/server/app/views/comparison_dashboard/download_speeds.html.erb
@@ -9,7 +9,6 @@
             data-controller="multi-line-chart"
             data-line-chart-data="<%= @download_speeds.to_json %>"
             data-parent-id="compare-download-speeds-widget<%= responsive ? '-responsive' : '' %>"
-            data-y-step-size="150"
             data-label-suffix=" Mbps"
             data-action="toggleLine@window->multi-line-chart#toggleLine"
             data-chart-id="compareDownloadSpeeds"

--- a/server/app/views/comparison_dashboard/latency.html.erb
+++ b/server/app/views/comparison_dashboard/latency.html.erb
@@ -9,7 +9,6 @@
             data-controller="multi-line-chart"
             data-line-chart-data="<%= @latency.to_json %>"
             data-parent-id="compare-latency-widget<%= responsive ? '-responsive' : '' %>"
-            data-y-step-size="1"
             data-label-suffix=" ms"
             data-action="toggleLine@window->multi-line-chart#toggleLine"
             data-chart-id="compareLatency"

--- a/server/app/views/comparison_dashboard/online_pods.html.erb
+++ b/server/app/views/comparison_dashboard/online_pods.html.erb
@@ -8,7 +8,6 @@
             data-controller="multi-line-chart"
             data-line-chart-data="<%= @online_pods.to_json %>"
             data-parent-id="online-pods-widget<%= responsive ? '-responsive' : ''%>"
-            data-y-step-size="1"
             data-label-suffix=""
             data-action="toggleLine@window->multi-line-chart#toggleLine"
             data-chart-id="onlinePods"

--- a/server/app/views/comparison_dashboard/upload_speeds.html.erb
+++ b/server/app/views/comparison_dashboard/upload_speeds.html.erb
@@ -9,7 +9,6 @@
             data-controller="multi-line-chart"
             data-line-chart-data="<%= @upload_speeds.to_json %>"
             data-parent-id="compare-upload-speeds-widget<%= responsive ? '-responsive' : '' %>"
-            data-y-step-size="150"
             data-label-suffix=" Mbps"
             data-action="toggleLine@window->multi-line-chart#toggleLine"
             data-chart-id="compareUploadSpeeds"

--- a/server/app/views/dashboard/download_speeds.html.erb
+++ b/server/app/views/dashboard/download_speeds.html.erb
@@ -8,7 +8,6 @@
             data-controller="multi-line-chart"
             data-line-chart-data="<%= @download_speeds.to_json %>"
             data-parent-id="download-speeds-widget<%= responsive ? '-responsive' : ''%>"
-            data-y-step-size="150"
             data-label-suffix=" Mbps"
             data-action="toggleLine@window->multi-line-chart#toggleLine"
             data-chart-id="downloadSpeeds"

--- a/server/app/views/dashboard/latency.html.erb
+++ b/server/app/views/dashboard/latency.html.erb
@@ -8,7 +8,6 @@
             data-controller="multi-line-chart"
             data-line-chart-data="<%= @latencies.to_json %>"
             data-parent-id="latency-widget<%= responsive ? '-responsive' : ''%>"
-            data-y-step-size="1"
             data-label-suffix=" ms"
             data-action="toggleLine@window->multi-line-chart#toggleLine"
             data-chart-id="latency"

--- a/server/app/views/dashboard/online_pods.html.erb
+++ b/server/app/views/dashboard/online_pods.html.erb
@@ -6,7 +6,6 @@
             data-controller="line-chart"
             data-line-chart-data="<%= @online_pods.to_json %>"
             data-parent-id="online-pods-widget"
-            data-y-step-size="25"
             data-query-time-interval="<%= @query_time_interval %>"
             data-skeleton-id="online-pods-chart-skeleton"
     ></canvas>

--- a/server/app/views/dashboard/upload_speeds.html.erb
+++ b/server/app/views/dashboard/upload_speeds.html.erb
@@ -8,7 +8,6 @@
             data-controller="multi-line-chart"
             data-line-chart-data="<%= @upload_speeds.to_json %>"
             data-parent-id="upload-speeds-widget<%= responsive ? '-responsive' : ''%>"
-            data-y-step-size="150"
             data-label-suffix=" Mbps"
             data-action="toggleLine@window->multi-line-chart#toggleLine"
             data-chart-id="uploadSpeeds"


### PR DESCRIPTION
- Fixed stretched comparison charts canvas
- Removed unnecessary data from charts
- Fixed inverted tooltip when not enough space at the end of the chart