### PR TITLE
Fixed join for network without AS

### DIFF
--- a/server/app/controllers/dashboard_controller.rb
+++ b/server/app/controllers/dashboard_controller.rb
@@ -71,7 +71,7 @@ class DashboardController < ApplicationController
     elsif sort_by == 'account'
       @locations = @locations.joins(:account).order('accounts.name')
     elsif sort_by == 'isp'
-      @locations = @locations.joins(clients: :autonomous_system).order('autonomous_systems.name')
+      @locations = @locations.left_outer_joins(clients: :autonomous_system).order('autonomous_systems.name')
     end
 
     if params[:account_id]


### PR DESCRIPTION
When sorting networks in the dashboard by ISP, previously, we were limiting the networks list just to those that joined to an AS, so it sometimes resulted in a smaller subset, which was wrong.