### PR TITLE
Fixed missing param in discord notifier

### DIFF
--- a/server/lib/events_notifier/discord_notifier.rb
+++ b/server/lib/events_notifier/discord_notifier.rb
@@ -215,7 +215,7 @@ class DiscordNotifier < EventsNotifier::Notifier
     fieldset.add_field(name: "Total in County", value: "#{location_info.extra[:locations_per_county_count]} out of #{Location::LOCATIONS_PER_COUNTY_GOAL} goal") if location_info.county
     fieldset.add_field(name: "Total in Place", value: "#{location_info.extra[:locations_per_place_count]} out of #{Location::LOCATIONS_PER_PLACE_GOAL} goal") if location_info.place && location_info.extra[:locations_per_place_count].present?
     fieldset.add_field(name: "Total in ISP in the County", value: "#{location_info.extra[:locations_per_isp_county_count]} out of #{Location::LOCATIONS_PER_ISP_PER_COUNTY_GOAL}") if location_info.extra[:as_org].present? && location_info.extra[:locations_per_isp_county_count].present?
-    fieldset.add_field(name: "Pod ID", value: self.pod_id(location_info.location))
+    fieldset.add_field(name: "Pod ID", value: self.pod_id(location_info.location, online: online))
   end
 
   def fill_online_notification_fieldset(location_info, fieldset, online: true)
@@ -224,15 +224,16 @@ class DiscordNotifier < EventsNotifier::Notifier
     fieldset.add_field(name: "Total in County", value: "#{location_info.extra[:locations_per_county_count]}") if location_info.county
     fieldset.add_field(name: "Total in Place", value: "#{location_info.extra[:locations_per_place_count]}") if location_info.place && location_info.extra[:locations_per_place_count]
     fieldset.add_field(name: "Total in ISP", value: "#{location_info.extra[:locations_per_isp_count]}") if location_info.extra[:as_org].present? && location_info.extra[:locations_per_isp_count].present?
-    fieldset.add_field(name: "Pod ID", value: self.pod_id(location_info.location))
+    fieldset.add_field(name: "Pod ID", value: self.pod_id(location_info.location, online: online))
   end
 
-  def pod_id(location)
+  def pod_id(location, online: true)
     # Try to grab the current online pod, it could happen that pod goes quickly offline right after, causing it to return nothing.
     # In these cases, we grab the latest updated pod, not caring for its status.
     pod_id = location.clients.where(online: online).order(:updated_at).last&.unix_user
     if pod_id.nil?
       pod_id = location.clients.order(:updated_at).last&.unix_user
     end
+    pod_id
   end
 end


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [🚨 Sentry Alert: Online param missing in discord notifier](https://linear.app/exactly/issue/TTAC-2840/sentry-alert-online-param-missing-in-discord-notifier)

Completes TTAC-2840.

- Bugs Fixed:
    - Fixed missing parameter in Discord notifier file.