### PR TITLE
Added magiclick to Dockerfile build step

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -18,7 +18,7 @@ ENV RAILS_ENV="production" \
 
 # Install packages needed for deployment
 RUN apt-get update -qq && \
-apt-get install --no-install-recommends -y curl libpq-dev libvips wkhtmltopdf && \
+apt-get install --no-install-recommends -y curl libpq-dev libvips wkhtmltopdf imagemagick && \
 rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 RUN apt upgrade -y

--- a/server/public/404.html
+++ b/server/public/404.html
@@ -7,6 +7,7 @@
     <meta property="og:image" content="og.png"/>
     <meta property="og:description" content="Telehealth Broadband Pilot Program"/>
     <meta property="og:site_name" content="Radar | Pods"/>
+    <meta property="og:url" content=""/>
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <link rel="stylesheet" href="/static/css/public.css"/>
 

--- a/server/public/500.html
+++ b/server/public/500.html
@@ -7,6 +7,7 @@
     <meta property="og:image" content="og.png"/>
     <meta property="og:description" content="Telehealth Broadband Pilot Program"/>
     <meta property="og:site_name" content="Radar | Pods"/>
+    <meta property="og:url" content=""/>
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <link rel="stylesheet" href="/static/css/public.css"/>
 


### PR DESCRIPTION
Fixed missing meta tags missing in 404/500 pages

## This PR includes the following Linear tasks:
* [🚨 Sentry Alert: MiniMagick missing in the v2 infra containers](https://linear.app/exactly/issue/TTAC-2841/sentry-alert-minimagick-missing-in-the-v2-infra-containers)

Completes TTAC-2841.

## Covering the following changes:
- Bugs Fixed:
    - Fixed MiniMagick missing from dockerfile builds
    - Fixed 500/404 pages missing some meta tags