### PR TITLE
Using pods account switcher from user profile page doesn't show correct accounts

### DIFF
--- a/server/app/controllers/users/registrations_controller.rb
+++ b/server/app/controllers/users/registrations_controller.rb
@@ -100,9 +100,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   # GET /resource/edit
-  # def edit
+  #def edit
   #  super
-  # end
+  #end
 
   # DELETE /custom_sign_out
   def custom_sign_out


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC-2713 : Using pods account switcher from user profile page doesn't show correct accounts](https://linear.app/exactly/issue/TTAC-2713/using-pods-account-switcher-from-user-profile-page-doesnt-show-correct)

Completes TTAC-2713.

## Covering the following changes:
- Bugs Fixed:
    - Missing to set the auth_holder on the edit user