### PR TITLE
Add condition for when no values are found for user location

### DIFF
--- a/speedtest_mobile/client_mobile_app/lib/core/services/locations_service/implementation/locations_service.dart
+++ b/speedtest_mobile/client_mobile_app/lib/core/services/locations_service/implementation/locations_service.dart
@@ -110,15 +110,17 @@ class LocationsService implements ILocationsService {
       },
     );
 
-    if (failureOrLocation.failure != null) {
-      Sentry.captureException(failureOrLocation.failure!.exception,
-          stackTrace: failureOrLocation.failure!.stackTrace);
-      return (latitude: null, longitude: null);
-    } else {
+    if (failureOrLocation.response != null && failureOrLocation.response!.length == 2) {
       return (
         latitude: failureOrLocation.response![0] as double,
         longitude: failureOrLocation.response![1] as double
       );
+    } else {
+      if (failureOrLocation.failure != null) {
+        Sentry.captureException(failureOrLocation.failure!.exception,
+            stackTrace: failureOrLocation.failure!.stackTrace);
+      }
+      return (latitude: null, longitude: null);
     }
   }
 


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC-2833 : Handle case when the response is an empty list when getting the user coordinates for the location service](https://linear.app/exactly/issue/TTAC-2833/handle-case-when-the-response-is-an-empty-list-when-getting-the-user)

Completes TTAC-2833

## Covering the following changes:
- Bugs Fixed:
    - Add condition for when no values are found for user location