### PR TITLE
Fix division by 0 and default unit for small time intervals

### DIFF
--- a/server/app/controllers/dashboard_controller.rb
+++ b/server/app/controllers/dashboard_controller.rb
@@ -94,13 +94,18 @@ class DashboardController < ApplicationController
 
     # For the online pods chart in particular, we draw way more points than download/upload speeds, latency, etc.
     # So we need to determine the time interval between each point to decide how to format the x-axis
-    diff_between_dots = (@online_pods[1]['x'].to_i - @online_pods[0]['x'].to_i) / 1000 # in seconds
-    if diff_between_dots >= 1.day.in_seconds
-      @query_time_interval = 'day'
-    elsif diff_between_dots >= 1.hour.in_seconds
-      @query_time_interval = 'hour'
-    elsif diff_between_dots >= 1.minute.in_seconds
-      @query_time_interval = 'minute'
+
+    if @online_pods.count > 1
+      diff_between_dots = (@online_pods[1]['x'].to_i - @online_pods[0]['x'].to_i) / 1000 # in seconds
+      if diff_between_dots >= 1.day.in_seconds
+        @query_time_interval = 'day'
+      elsif diff_between_dots >= 1.hour.in_seconds
+        @query_time_interval = 'hour'
+      elsif diff_between_dots >= 1.minute.in_seconds
+        @query_time_interval = 'minute'
+      else
+        @query_time_interval = 'second'
+      end
     else
       @query_time_interval = 'second'
     end

--- a/server/app/helpers/dashboard_helper.rb
+++ b/server/app/helpers/dashboard_helper.rb
@@ -603,7 +603,15 @@ module DashboardHelper
          .map { |unit| [unit, time_diff / 1.send(unit)]}
          .sort_by { |unit, dots| (DOT_LIMIT - dots).abs }
          .filter { |unit, dots| dots > DOT_MINIMUM }
-         .first[0]
+         .first
+
+    # Check if we have a best unit available. In cases where the time difference is too small, we might not have any
+    # so we default the value to the smallest available unit
+    if best_unit.nil?
+      best_unit = units.first
+    else
+      best_unit = best_unit.first
+    end
 
     dots_in_interval = time_diff / 1.send(best_unit)
     step = 1

--- a/server/app/views/dashboard/components/widgets/outages/_status_bar.html.erb
+++ b/server/app/views/dashboard/components/widgets/outages/_status_bar.html.erb
@@ -7,6 +7,7 @@
     <% outage_group_id = entry[0] %>
     <% group_data = entry[1] %>
     <% full_time_span = (end_date - start_date).to_i %>
+    <% full_time_span = 1 if full_time_span == 0 %>
     <% normalized_duration = group_data[:started_at].to_i < start_date.to_i ? group_data[:resolved_at].to_i - start_date.to_i : group_data[:duration].to_i %>
     <% width = (normalized_duration / full_time_span.to_f) * 100 %>
     <% width = 100 if width > 100 %>


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC-2847 : When getting the interval step, check that the sql returned something valid. \[Dashboards\]](https://linear.app/exactly/issue/TTAC-2847/when-getting-the-interval-step-check-that-the-sql-returned-something)
* [TTAC-2843 : When calculating the left size, check it is constrained.](https://linear.app/exactly/issue/TTAC-2843/when-calculating-the-left-size-check-it-is-constrained)

Completes TTAC-2847 and TTAC-2843.

## Covering the following changes:
- Bugs Fixed:
    - Fixed infinity thrown in a 0 division
    - Fixed online pods chart not loading when timeframe was too small