### PR TITLE
Handle error when sending the speed test results and it fails

### DIFF
--- a/speedtest/src/context/SpeedTestContext.js
+++ b/speedtest/src/context/SpeedTestContext.js
@@ -85,12 +85,14 @@ export const SpeedTestContextProvider = ({children}) => {
       downloadMeasurement: saveDownloadValue,
       uploadComplete: uploadComplete,
       uploadMeasurement: saveUploadValue,
-      error: err => {
-        setLoading(false);
-        setIsRunning(false);
-        setError(err);
-      },
+      error: setErrorState,
     });
+  }
+
+  const setErrorState = (err) => {
+    setLoading(false);
+    setIsRunning(false);
+    setError(err);
   }
 
   const saveDownloadValue = (data) => {
@@ -170,7 +172,7 @@ export const SpeedTestContextProvider = ({children}) => {
       setIsRunning(false);
       setCurrentStep(STEPS.SPEED_TEST_RESULTS);
     } catch (e) {
-      notifyError(e);
+      setErrorState(e);
     }
   };
 

--- a/speedtest/src/context/UserData.js
+++ b/speedtest/src/context/UserData.js
@@ -26,22 +26,13 @@ export const emptyAddress = {
   house_number: ''
 };
 
-export const emptyNetworkLocation = {
-  id: -1,
-  iconSrc: null,
-  iconSelectedSrc: null,
-  iconLightSrc: null,
-  iconPopupSrc: null,
-  text: '',
-};
-
 export const UserDataContextProvider = ({children}) => {
 
   const [userData, setUserData] = useState({
     currentStep: STEPS.INITIAL,
     address: emptyAddress,
     terms: false,
-    networkLocation: emptyNetworkLocation,
+    networkLocation: null,
     networkType: null,
     networkCost: '', // init with empty string to prevent console error regarding controlled vs. uncontrolled input value change
     addressProvider: ADDRESS_PROVIDER.MANUAL,

--- a/speedtest/src/utils/apiRequests.js
+++ b/speedtest/src/utils/apiRequests.js
@@ -22,44 +22,48 @@ export const sendRawData = (rawData, startTimestamp, userData, clientId) => {
   const { networkLocation, networkType, networkCost, accuracy, altitude, addressProvider, altitudeAccuracy, speed, heading, expectedDownloadSpeed, expectedUploadSpeed, contactInformation } = userData;
   const { address, city, state, house_number, street, postal_code } = userData.address;
   const location = userData.address.coordinates;
-  return fetch(`${API_URL}/speed_tests?client_id=${clientId}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      result: { raw: rawData },
-      speed_test: {
-        latitude: location[0],
-        longitude: location[1],
-        tested_at: startTimestamp,
-        address,
-        city,
-        street,
-        state,
-        postal_code,
-        house_number,
-        network_location: networkLocation?.text ?? null,
-        network_type: networkType?.text ?? null,
-        network_cost: networkCost,
-        altitude,
-        accuracy,
-        address_provider: addressProvider,
-        alt_accuracy: altitudeAccuracy,
-        speed,
-        heading,
-        expected_download_speed: expectedDownloadSpeed,
-        expected_upload_speed: expectedUploadSpeed,
-        client_first_name: contactInformation.firstName,
-        client_last_name: contactInformation.lastName,
-        client_email: contactInformation.email,
-        client_phone: contactInformation.phone
-      }
-    }),
-  })
+  try {
+    return fetch(`${API_URL}/speed_tests?client_id=${clientId}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        result: { raw: rawData },
+        speed_test: {
+          latitude: location[0],
+          longitude: location[1],
+          tested_at: startTimestamp,
+          address,
+          city,
+          street,
+          state,
+          postal_code,
+          house_number,
+          network_location: networkLocation?.text ?? null,
+          network_type: networkType?.text ?? null,
+          network_cost: networkCost,
+          altitude,
+          accuracy,
+          address_provider: addressProvider,
+          alt_accuracy: altitudeAccuracy,
+          speed,
+          heading,
+          expected_download_speed: expectedDownloadSpeed,
+          expected_upload_speed: expectedUploadSpeed,
+          client_first_name: contactInformation.firstName,
+          client_last_name: contactInformation.lastName,
+          client_email: contactInformation.email,
+          client_phone: contactInformation.phone
+        }
+      }),
+    })
     .then(res => {
       if(!res.ok) throw new Error('Error creating new speed test!');
       return res.json();
     })
-    .catch(notifyError);
+  } catch (e) {
+    notifyError(e);
+    throw new Error('Error saving speed test results. Please try again later.');
+  }
 };
 
 export const sendSpeedTestFormInformation = async (userData, clientId) => {


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC-2845 : Handle error when sendRawData fails. setAutonomousSystem is done even if the POST failed](https://linear.app/exactly/issue/TTAC-2845/handle-error-when-sendrawdata-fails-setautonomoussystem-is-done-even)

Completes TTAC-2845.

## Covering the following changes:
- Bugs Fixed:
    - Handle error when sending the speed test results and it fails