### PR TITLE
Fixed some exceptions + added snack bar context to have generic alerts

### DIFF
--- a/speedtest/src/App.jsx
+++ b/speedtest/src/App.jsx
@@ -5,6 +5,7 @@ import {ConnectionContextProvider} from "./context/ConnectionContext";
 import MainPage from "./components/MainPage/MainPage";
 import {UserDataContextProvider} from "./context/UserData";
 import {SpeedTestContextProvider} from "./context/SpeedTestContext";
+import {AlertsContextProvider} from "./context/AlertsContext";
 
 // Application entry point, would hold all logic for state management
 // of multistep process
@@ -15,15 +16,17 @@ const App = ({ config }) => {
   return (
     <ViewportContextProvider>
       <ConfigContextProvider value={config}>
-        <ThemeProvider theme={theme}>
-          <ConnectionContextProvider>
-            <UserDataContextProvider>
-              <SpeedTestContextProvider>
-                <MainPage config={config}/>
-              </SpeedTestContextProvider>
-            </UserDataContextProvider>
-          </ConnectionContextProvider>
-        </ThemeProvider>
+        <AlertsContextProvider>
+          <ThemeProvider theme={theme}>
+            <ConnectionContextProvider>
+              <UserDataContextProvider>
+                <SpeedTestContextProvider>
+                  <MainPage config={config}/>
+                </SpeedTestContextProvider>
+              </UserDataContextProvider>
+            </ConnectionContextProvider>
+          </ThemeProvider>
+        </AlertsContextProvider>
       </ConfigContextProvider>
     </ViewportContextProvider>
   );

--- a/speedtest/src/components/AllResultsPage/AllResultsPage.jsx
+++ b/speedtest/src/components/AllResultsPage/AllResultsPage.jsx
@@ -24,6 +24,7 @@ import {DEFAULT_GRAY_BUTTON_TEXT_COLOR} from "../../utils/colors";
 import {addMetadataToResults} from "../../utils/metadata";
 import ConnectionContext from "../../context/ConnectionContext";
 import {isArray} from "leaflet/src/core/Util";
+import AlertsContext, {SNACKBAR_TYPES} from "../../context/AlertsContext";
 
 const mapWrapperStyle = {
   width: '100%',
@@ -60,6 +61,7 @@ const AllResultsPage = ({ givenLocation, maxHeight, givenZoom }) => {
   const {isExtraSmallSizeScreen, isSmallSizeScreen, isMediumSizeScreen} = useViewportSizes();
   const config = useContext(ConfigContext);
   const {setNoInternet} = useContext(ConnectionContext);
+  const {showSnackbarMessage} = useContext(AlertsContext);
   let timerId;
 
 
@@ -189,7 +191,8 @@ const AllResultsPage = ({ givenLocation, maxHeight, givenZoom }) => {
       .then(res => handleTestsWithBoundsResult(res))
       .catch(err => {
         if(isNoConnectionError(err)) setNoInternet(true);
-        notifyError(err)
+        notifyError(err);
+        showSnackbarMessage('There has been an error fetching speedtests!', SNACKBAR_TYPES.ERROR);
       })
       .finally(() => setFetchingResults(false));
   }

--- a/speedtest/src/components/MainPage/MainPage.jsx
+++ b/speedtest/src/components/MainPage/MainPage.jsx
@@ -8,8 +8,9 @@ import HistoryPage from "../HistoryPage/HistoryPage";
 import ConnectionContext from "../../context/ConnectionContext";
 import NoInternetModal from "../common/NoInternetModal";
 import OverviewPage from "../OverviewPage/OverviewPage";
-import UserData from "../../context/UserData";
 import UserDataContext from "../../context/UserData";
+import AlertsContext from "../../context/AlertsContext";
+import {Alert, Snackbar} from "@mui/material";
 
 const MainPage = ({config}) => {
 
@@ -35,6 +36,7 @@ const MainPage = ({config}) => {
   const {noInternet, setNoInternet} = useContext(ConnectionContext);
   const {userData} = useContext(UserDataContext);
   const {currentStep} = userData;
+  const {closeSnackbar, isSnackbarVisible, snackbarMessage, snackbarType} = useContext(AlertsContext);
 
   useEffect(() => {
     setSpecificSpeedTestStep(currentStep);
@@ -96,6 +98,19 @@ const MainPage = ({config}) => {
     <Frame config={config} setStep={setStep} step={step}>
       {renderContent()}
       <NoInternetModal isOpen={noInternet} closeModal={() => setNoInternet(false)}/>
+      <Snackbar open={isSnackbarVisible}
+                onClose={closeSnackbar}
+                autoHideDuration={3000}
+      >
+        <Alert severity={snackbarType}
+               variant={'filled'}
+               sx={{width: '100%'}}
+               color={snackbarType}
+               onClose={closeSnackbar}
+        >
+          {snackbarMessage}
+        </Alert>
+      </Snackbar>
     </Frame>
   )
 }

--- a/speedtest/src/components/StepsPage/Pages/LocationSearchStep/MyMapModal.jsx
+++ b/speedtest/src/components/StepsPage/Pages/LocationSearchStep/MyMapModal.jsx
@@ -26,6 +26,7 @@ import {ADDRESS_PROVIDER} from "../../../../utils/userMetadata";
 import UserDataContext from "../../../../context/UserData";
 import rightArrowWhite from "../../../../assets/right-arrow-white.png";
 import './MyMapModal.css';
+import AlertsContext, {SNACKBAR_TYPES} from "../../../../context/AlertsContext";
 
 const commonModalStyle = {
   boxShadow: DEFAULT_MODAL_BOX_SHADOW,
@@ -149,6 +150,7 @@ const MyMapModal = ({
   const {userData, setUserData} = useContext(UserDataContext);
   const {isExtraSmallSizeScreen, isSmallSizeScreen, isMediumSizeScreen} = useViewportSizes();
   const {setNoInternet} = useContext(ConnectionContext);
+  const {showSnackbarMessage} = useContext(AlertsContext);
   const markerRef = useRef(null);
 
   const [loading, setLoading] = useState(false);
@@ -254,6 +256,7 @@ const MyMapModal = ({
     } catch (e) {
       if(isNoConnectionError(e)) setNoInternet(true);
       notifyError(e);
+      showSnackbarMessage('There has been an error fetching coordinates!', SNACKBAR_TYPES.ERROR);
     }
   }
 

--- a/speedtest/src/context/AlertsContext.js
+++ b/speedtest/src/context/AlertsContext.js
@@ -1,0 +1,40 @@
+import {createContext, useState} from "react";
+
+export const SNACKBAR_TYPES = {
+  SUCCESS: 'success',
+  ERROR: 'error',
+  INFO: 'info',
+  WARNING: 'warning'
+}
+
+/**
+ * Custom context provider to show error snackbars application-wide
+ * By exposing the context on our App.jsx, custom hooks can be called
+ * to show generic alert messages across all screens.
+ * @type {React.Context<{}>}
+ */
+const AlertsContext = createContext({});
+
+export const AlertsContextProvider = ({children}) => {
+  const [isSnackbarVisible, setIsSnackbarVisible] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState('');
+  const [snackbarType, setSnackbarType] = useState(SNACKBAR_TYPES.INFO);
+
+  const closeSnackbar = () => {
+    setIsSnackbarVisible(false);
+  }
+
+  const showSnackbarMessage = (message, type = SNACKBAR_TYPES.INFO) => {
+    setSnackbarMessage(message);
+    setSnackbarType(type);
+    setIsSnackbarVisible(true);
+  }
+
+  return (
+    <AlertsContext.Provider value={{snackbarType, snackbarMessage, isSnackbarVisible, showSnackbarMessage, closeSnackbar}}>
+      {children}
+    </AlertsContext.Provider>
+  )
+}
+
+export default AlertsContext;

--- a/speedtest/src/context/SpeedTestContext.js
+++ b/speedtest/src/context/SpeedTestContext.js
@@ -123,7 +123,7 @@ export const SpeedTestContextProvider = ({children}) => {
     setCounter(0);
     setProgress(0);
     setRunningTestType('upload');
-    if(data?.LastClientMeasurement?.MeanClientMbps) {
+    if(data?.LastClientMeasurement?.MeanClientMbps && data?.LastServerMeasurement?.TCPInfo) {
       downloadRef.current = data.LastClientMeasurement.MeanClientMbps;
       setDownloadValue(data.LastClientMeasurement.MeanClientMbps);
       latencyRef.current = data.LastServerMeasurement.TCPInfo.MinRTT / 1000;
@@ -140,7 +140,7 @@ export const SpeedTestContextProvider = ({children}) => {
     setCounter(100);
     setProgress(100);
     let currentData = speedTestData.rawData;
-    if(data?.LastServerMeasurement) {
+    if(data?.LastServerMeasurement?.TCPInfo) {
       uploadRef.current = (data.LastServerMeasurement.TCPInfo.BytesReceived / data.LastServerMeasurement.TCPInfo.ElapsedTime) * 8;
       setUploadValue(
         (data.LastServerMeasurement.TCPInfo.BytesReceived / data.LastServerMeasurement.TCPInfo.ElapsedTime) * 8

--- a/speedtest/src/context/UserData.js
+++ b/speedtest/src/context/UserData.js
@@ -26,25 +26,27 @@ export const emptyAddress = {
   house_number: ''
 };
 
+export const emptyUserData = {
+  currentStep: STEPS.INITIAL,
+  address: emptyAddress,
+  terms: false,
+  networkLocation: null,
+  networkType: null,
+  networkCost: '', // init with empty string to prevent console error regarding controlled vs. uncontrolled input value change
+  addressProvider: ADDRESS_PROVIDER.MANUAL,
+  altitude: null, // provided by browser geolocation API
+  accuracy: null, // provided by browser geolocation API
+  altitudeAccuracy: null, // provided by browser geolocation API
+  speed: null, // provided by browser geolocation API
+  heading: null, // provided by browser geolocation API
+  expectedDownloadSpeed: undefined,
+  expectedUploadSpeed: undefined,
+  contactInformation: emptyContactInformation,
+};
+
 export const UserDataContextProvider = ({children}) => {
 
-  const [userData, setUserData] = useState({
-    currentStep: STEPS.INITIAL,
-    address: emptyAddress,
-    terms: false,
-    networkLocation: null,
-    networkType: null,
-    networkCost: '', // init with empty string to prevent console error regarding controlled vs. uncontrolled input value change
-    addressProvider: ADDRESS_PROVIDER.MANUAL,
-    altitude: null, // provided by browser geolocation API
-    accuracy: null, // provided by browser geolocation API
-    altitudeAccuracy: null, // provided by browser geolocation API
-    speed: null, // provided by browser geolocation API
-    heading: null, // provided by browser geolocation API
-    expectedDownloadSpeed: undefined,
-    expectedUploadSpeed: undefined,
-    contactInformation: emptyContactInformation,
-  });
+  const [userData, setUserData] = useState(emptyUserData);
 
   const setAddress = address => setUserData(prev => ({...prev, address}));
   const setTerms = status => setUserData(prev => ({...prev, terms: status}));

--- a/speedtest/src/index.css
+++ b/speedtest/src/index.css
@@ -21,7 +21,7 @@
   font-weight: normal;
 }
 
-* {
+*:not(.MuiAlert-icon) {
   font-family: Mulish, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   color: #110e4c;
   font-variation-settings: 'wght' 400;
@@ -127,4 +127,10 @@
 
 input {
   font-family: Mulish, serif;
+}
+
+.MuiSnackbar-root > div > div.MuiAlert-message,
+.MuiSnackbar-root > div > div.MuiAlert-action > button > svg > path,
+.MuiSnackbar-root > div > div.MuiAlert-icon > svg > path {
+  color: white;
 }

--- a/speedtest/src/utils/apiRequests.js
+++ b/speedtest/src/utils/apiRequests.js
@@ -72,6 +72,7 @@ export const sendSpeedTestFormInformation = async (userData, clientId) => {
     return emptySubmission.id;
   } catch (err) {
     notifyError(err);
+    throw new Error(err);
   }
 };
 


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC-2786: 🚨 EXCEPTION: Cannot read properties of undefined (reading 'TCPInfo')](https://linear.app/exactly/issue/TTAC-2786/exception-cannot-read-properties-of-undefined-reading-tcpinfo)
* [TTAC-2798: Add Error Treatment for Fetches around the app to prevent "Failed to Fetch" errors](https://linear.app/exactly/issue/TTAC-2798/add-error-treatment-for-fetches-around-the-app-to-prevent-failed-to)
* [TTAC-2859: Fix Errors in speedtest app, causing a blank screen to appear](https://linear.app/exactly/issue/TTAC-2859/fix-errors-in-speedtest-app-causing-a-blank-screen-to-appear)

Completes TTAC-2786, TTAC-2798 and TTAC-2859.

## Covering the following changes:
- Bugs Fixed:
    - Fixed exception thrown when speedtest response has no TCPInfo
    - Fixed exception thrown when no local speedtests are found
- Other:
    - Created app-wide context to show snackbars for alerts for different severities