### PR TITLE
update http to ws and https to wss for wifi tracker service

### DIFF
--- a/speedtest_mobile/client_mobile_app/lib/core/rest_client/rest_client.dart
+++ b/speedtest_mobile/client_mobile_app/lib/core/rest_client/rest_client.dart
@@ -13,8 +13,15 @@ class RestClient {
   String get baseUrl => _baseUrl;
 
   String get ws {
-    final url = _baseUrl.replaceAll('http://', '').replaceAll('https://', '');
-    return 'ws://$url$_ws';
+    String url = _baseUrl;
+    final http = RegExp(r'^http://');
+    final https = RegExp(r'^https://');
+    if (http.hasMatch(url)) {
+      url = url.replaceFirst(http, 'ws://');
+    } else if (https.hasMatch(url)) {
+      url = url.replaceFirst(https, 'wss://');
+    }
+    return '$url$_ws';
   }
 
   String _combineUrl(String url) {


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC-2829: 🚨 Sentry Alert: WebSocketException: WebSocketException: Connection to 'http://pods.radartoolkit.com:0/client_api/v1/ws#' was not upgraded to websocket](https://linear.app/exactly/issue/TTAC-2829/sentry-alert-websocketexception-websocketexception-connection-to)
Completes TTAC-2829.

## Covering the following changes:
- Bugs Fixed:
    - Fix socket url for wifi tracking service
