### PR TITLE
Fix missing authlog on Watchdog

### DIFF
--- a/pods_agent/watchdog/authlog.go
+++ b/pods_agent/watchdog/authlog.go
@@ -43,6 +43,9 @@ func scanAuthLog(c *config.Config, authLog []byte, lastTime time.Time) ([]LoginE
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		text := strings.Replace(string(line), "\x00", "", -1)
+		if strings.HasPrefix(text, "--") {
+			continue
+		}
 		match := connectionRegexp.FindStringSubmatch(text)
 		if len(match) == 5 {
 			t, err = parseDateFromAuthLog(match[1], match[2], match[3])

--- a/pods_agent/watchdog/spec.go
+++ b/pods_agent/watchdog/spec.go
@@ -75,7 +75,7 @@ type SystemManager interface {
 	Interfaces() (network.NetInterfaces, error)
 	// Reboot makes the system reboot
 	Reboot() error
-	// GetAuthFile returns a log of authentications in the system
+	// GetAuthFile returns logs from systemd-logind
 	GetAuthLogFile() ([]byte, error)
 	// GetSysTimezone
 	GetSysTimezone() (*time.Location, error)


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC - 2868 - Update the Pods base image](https://linear.app/exactly/issue/TTAC-2868/update-the-pods-base-image)

## Covering the following changes:
- Bugs Fixed:
    - Fixed error caused by watchdog running in newer PI os versions that don't have authlog files. It now fallback to read from `journalctl`.
