### PR TITLE
Update Pod OS to 2024-07-04-raspios-bookworm-arm64-lite

### DIFF
--- a/pods_agent/pods_os/README.md
+++ b/pods_agent/pods_os/README.md
@@ -18,7 +18,7 @@ If you don't have a bridge, you can see how to setup one [here](https://wiki.qem
 
 ## Setup POD the Image
 
-Download the [POD OS Image](https://console.cloud.google.com/storage/browser/radar-disk-images).
+Download the [POD OS Image](https://exactlylabsinc.sharepoint.com/:f:/s/product/ElS-CZauqU1Kt_7qL7PHc1MBqxzih3MX0Jdt1cLpVlTMlA?e=KKSKBp).
 Select which version you want emulate.
 
 Once the download finishes, run:

--- a/pods_agent/pods_os/pod_image_files/radar_agent.service
+++ b/pods_agent/pods_os/pod_image_files/radar_agent.service
@@ -3,6 +3,7 @@ Description=Radar Agent
 After=network.target auditd.service
 
 [Service]
+Environment="GODEBUG=netdns=cgo"
 ExecStart=${AGENT_BINARY_PATH}
 KillMode=process
 Restart=always

--- a/pods_agent/pods_os/pod_image_files/withinnewimage.sh
+++ b/pods_agent/pods_os/pod_image_files/withinnewimage.sh
@@ -10,6 +10,8 @@ apt-get install -y unattended-upgrades apt-listchanges sudo
 echo "APT::Periodic::Update-Package-Lists \"1\";" > /etc/apt/apt.conf.d/20auto-upgrades
 echo "APT::Periodic::Unattended-Upgrade \"1\";" >> /etc/apt/apt.conf.d/20auto-upgrades
 
+systemctl disable userconfig # New PI OS asks for a user on first boot. Disable it.
+
 systemctl enable radar_agent
 systemctl disable getty@
 systemctl enable podwatchdog@

--- a/pods_agent/pods_os/scripts/create_master_image.sh
+++ b/pods_agent/pods_os/scripts/create_master_image.sh
@@ -77,17 +77,24 @@ curl -L --output ${BUILD_DIR}/$WATCHDOG_BINARY_NAME $RADAR_WATCHDOG_BIN_URL
 
 #### NOTE: Images after 2022-01-28 appear to use .xz and before use .zip
 # Decompress the .xz file
-#VERSION=2022-04-04-raspios-bullseye-arm64-lite.img
-# if [ ! -f $VERSION.xz ]; then
-# curl -L --output $VERSION.xz https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2022-04-07/$VERSION.xz
-# fi
-# unxz $VERSION.xz
+URL=https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-2024-07-04/2024-07-04-raspios-bookworm-arm64-lite.img.xz
+VERSION=2024-07-04-raspios-bookworm-arm64-lite.img
+XZ_FILE=${VERSION}.xz
 
-VERSION=2022-01-28-raspios-bullseye-arm64-lite.img
-if [ ! -f ${BUILD_DIR}/${VERSION}.zip ]; then
-curl -L --output ${BUILD_DIR}/${VERSION}.zip https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2022-01-28/2022-01-28-raspios-bullseye-arm64-lite.zip
+
+if [ ! -f ${BUILD_DIR}/${VERSION}.xz ] | [ ! -f ${BUILD_DIR}/${VERSION} ]; then
+  curl -L --output ${BUILD_DIR}/${XZ_FILE} $URL
 fi
-unzip -qod ${BUILD_DIR} ${BUILD_DIR}/${VERSION}.zip
+
+if [ ! -f ${BUILD_DIR}/${VERSION} ]; then
+  unxz ${BUILD_DIR}/${XZ_FILE}
+fi
+
+# VERSION=2022-01-28-raspios-bullseye-arm64-lite.img
+# if [ ! -f ${BUILD_DIR}/${VERSION}.zip ]; then
+# curl -L --output ${BUILD_DIR}/${VERSION}.zip https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2022-01-28/2022-01-28-raspios-bullseye-arm64-lite.zip
+# fi
+# unzip -qod ${BUILD_DIR} ${BUILD_DIR}/${VERSION}.zip
 
 # Mount the .img in an available loop (/dev/loop) device
 # This makes plain files accessible as block devices

--- a/pods_agent/pods_os/scripts/flash.sh
+++ b/pods_agent/pods_os/scripts/flash.sh
@@ -4,7 +4,7 @@ set -e
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-IMAGE_LOCATION=${SCRIPT_DIR}/../dist/radar.img
+IMAGE_LOCATION=${SCRIPT_DIR}/dist/radar.img
 
 if [[ ! -f "$IMAGE_LOCATION" ]]; then
     echo "Image not found at '$IMAGE_LOCATION' as expected"


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC-2873 - Test new PI OS version in physical pods](https://linear.app/exactly/issue/TTAC-2873/update-and-test-new-pi-os-version-in-physical-pods)

## Covering the following changes:
- Other:
    - Updated the base image for new pods to use the latest PI OS version: 2024-07-04-raspios-bookworm-arm64-lite
