### PR TITLE
Add styling to Devise authentication emails

### DIFF
--- a/server/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/server/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,10 +1,21 @@
-<html>
+<html lang="en">
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type'/>
-    <link href='https://fonts.googleapis.com/css?family=Mulish:400,700' rel='stylesheet' type='text/css'>
     <style>
-      #main>* {
-        font-family: Mulish, sans-serif;
+      @import url('https://fonts.googleapis.com/css2?family=Mulish:wght@200..1000&display=swap');
+
+      * {
+        font-family: 'Mulish', Roboto, sans-serif;
+        font-optical-sizing: auto;
+        font-style: normal;
+        font-weight: 400;
+        font-variation-settings: 'wght' 400;
+      }
+      .font-bold {
+        font-weight: 700;
+        font-variation-settings: 'wght' 700;
+      }
+      #main > * {
         padding: 0 48px;
       }
       p {
@@ -14,15 +25,15 @@
   </head>
   <body>
     <div id="main" style="margin: 29px auto 32px; width: 570px; text-align: center">
-      <div style="color: #110E4C; text-align: left; font-size: 15px; line-height: 20px">
-        <p style="font-size: 16px; font-weight: bold; margin-bottom: 16px">
+      <div style="color: #110E4C; text-align: left">
+        <p class="font-bold" style="font-size: 16px; margin-bottom: 16px">
           Hi, <%= @resource.email %>
         </p>
-        <p>
+        <p style="font-size: 15px">
           Welcome to Radar! Please click the button below to confirm your
           account email.
         </p>
-        <%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token), style: 'background-color: #4B7BE5; color: white; font-size: 15px; font-weight: bold; text-decoration: none; display: block; width: max-content; height: 20px; border: none; border-radius: 6px; padding: 12px 24px; margin: 48px auto 64px;' %>
+        <%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token), class: 'font-bold', style: 'background-color: #4B7BE5; color: white; font-size: 15px; text-decoration: none; display: block; width: max-content; height: 20px; border: none; border-radius: 6px; padding: 12px 24px; margin: 48px auto 64px;' %>
       </div>
       <div style="background-color: #F6F8FA; height: 2px; margin: 24px auto"></div>
       <p style="color: #B5B5C3; font-size: 14px">

--- a/server/app/views/devise/mailer/email_changed.html.erb
+++ b/server/app/views/devise/mailer/email_changed.html.erb
@@ -1,10 +1,21 @@
-<html>
+<html lang="en">
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type'/>
-    <link href='https://fonts.googleapis.com/css?family=Mulish:400,700' rel='stylesheet' type='text/css'>
     <style>
-      #main>* {
-        font-family: Mulish, sans-serif;
+      @import url('https://fonts.googleapis.com/css2?family=Mulish:wght@200..1000&display=swap');
+
+      * {
+        font-family: 'Mulish', Roboto, sans-serif;
+        font-optical-sizing: auto;
+        font-style: normal;
+        font-weight: 400;
+        font-variation-settings: 'wght' 400;
+      }
+      .font-bold {
+        font-weight: 700;
+        font-variation-settings: 'wght' 700;
+      }
+      #main > * {
         padding: 0 48px;
       }
       p {
@@ -14,11 +25,11 @@
   </head>
   <body>
     <div id="main" style="margin: 29px auto 32px; width: 570px; text-align: center">
-      <div style="color: #110E4C; text-align: left; font-size: 15px; line-height: 20px">
-        <p style="font-size: 16px; font-weight: bold; margin-bottom: 16px">
+      <div style="color: #110E4C; text-align: left">
+        <p class="font-bold" style="font-size: 16px; margin-bottom: 16px">
           Hi, <%= @resource.email %>
         </p>
-        <p>
+        <p style="font-size: 15px">
           We're contacting you to notify you that your email is being changed to
           <% if @resource.try(:unconfirmed_email?) %>
             <%= @resource.unconfirmed_email %>.

--- a/server/app/views/devise/mailer/password_change.html.erb
+++ b/server/app/views/devise/mailer/password_change.html.erb
@@ -1,10 +1,21 @@
-<html>
+<html lang="en">
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type'/>
-    <link href='https://fonts.googleapis.com/css?family=Mulish:400,700' rel='stylesheet' type='text/css'>
     <style>
-      #main>* {
-        font-family: Mulish, sans-serif;
+      @import url('https://fonts.googleapis.com/css2?family=Mulish:wght@200..1000&display=swap');
+
+      * {
+        font-family: 'Mulish', Roboto, sans-serif;
+        font-optical-sizing: auto;
+        font-style: normal;
+        font-weight: 400;
+        font-variation-settings: 'wght' 400;
+      }
+      .font-bold {
+        font-weight: 700;
+        font-variation-settings: 'wght' 700;
+      }
+      #main > * {
         padding: 0 48px;
       }
       p {
@@ -14,11 +25,11 @@
   </head>
   <body>
     <div id="main" style="margin: 29px auto 32px; width: 570px; text-align: center">
-      <div style="color: #110E4C; text-align: left; font-size: 15px; line-height: 20px">
-        <p style="font-size: 16px; font-weight: bold; margin-bottom: 16px">
+      <div style="color: #110E4C; text-align: left">
+        <p class="font-bold" style="font-size: 16px; margin-bottom: 16px">
           Hi, <%= @resource.email %>
         </p>
-        <p>
+        <p style="font-size: 15px">
           We're contacting you to notify you that your password has been
           changed.
         </p>

--- a/server/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/server/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,10 +1,21 @@
-<html>
+<html lang="en">
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type'/>
-    <link href='https://fonts.googleapis.com/css?family=Mulish:400,700' rel='stylesheet' type='text/css'>
     <style>
-      #main>* {
-        font-family: Mulish, sans-serif;
+      @import url('https://fonts.googleapis.com/css2?family=Mulish:wght@200..1000&display=swap');
+
+      * {
+        font-family: 'Mulish', Roboto, sans-serif;
+        font-optical-sizing: auto;
+        font-style: normal;
+        font-weight: 400;
+        font-variation-settings: 'wght' 400;
+      }
+      .font-bold {
+        font-weight: 700;
+        font-variation-settings: 'wght' 700;
+      }
+      #main > * {
         padding: 0 48px;
       }
       p {
@@ -14,16 +25,16 @@
   </head>
   <body>
     <div id="main" style="margin: 29px auto 32px; width: 570px; text-align: center">
-      <div style="color: #110E4C; text-align: left; font-size: 15px; line-height: 20px">
-        <p style="font-size: 16px; font-weight: bold; margin-bottom: 16px">
+      <div style="color: #110E4C; text-align: left">
+        <p class="font-bold" style="font-size: 16px; margin-bottom: 16px">
           Hi, <%= @resource.email %>
         </p>
-        <p>
+        <p style="font-size: 15px">
           Someone has requested to change your password. Click the button below
           to create a new password.
         </p>
-        <%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token), style: 'background-color: #4B7BE5; color: white; font-size: 15px; font-weight: bold; text-decoration: none; display: block; width: max-content; height: 20px; border: none; border-radius: 6px; padding: 12px 24px; margin: 48px auto 64px;' %>
-        <p>
+        <%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token), class: 'font-bold', style: 'background-color: #4B7BE5; color: white; font-size: 15px; text-decoration: none; display: block; width: max-content; height: 20px; border: none; border-radius: 6px; padding: 12px 24px; margin: 48px auto 64px;' %>
+        <p style="font-size: 15px">
           If you didn't request this, please ignore this email.
           Your password won't change until you click the button above and create
           a new one.

--- a/server/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/server/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,10 +1,21 @@
-<html>
+<html lang="en">
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type'/>
-    <link href='https://fonts.googleapis.com/css?family=Mulish:400,700' rel='stylesheet' type='text/css'>
     <style>
-      #main>* {
-        font-family: Mulish, sans-serif;
+      @import url('https://fonts.googleapis.com/css2?family=Mulish:wght@200..1000&display=swap');
+
+      * {
+        font-family: 'Mulish', Roboto, sans-serif;
+        font-optical-sizing: auto;
+        font-style: normal;
+        font-weight: 400;
+        font-variation-settings: 'wght' 400;
+      }
+      .font-bold {
+        font-weight: 700;
+        font-variation-settings: 'wght' 700;
+      }
+      #main > * {
         padding: 0 48px;
       }
       p {
@@ -14,19 +25,19 @@
   </head>
   <body>
     <div id="main" style="margin: 29px auto 32px; width: 570px; text-align: center">
-      <div style="color: #110E4C; text-align: left; font-size: 15px; line-height: 20px">
-        <p style="font-size: 16px; font-weight: bold; margin-bottom: 16px">
+      <div style="color: #110E4C; text-align: left">
+        <p class="font-bold" style="font-size: 16px; margin-bottom: 16px">
           Hi, <%= @resource.email %>
         </p>
-        <p style="margin-bottom: 10px">
+        <p style="font-size: 15px; margin-bottom: 10px">
           Your account has been locked due to an excessive number of
           unsuccessful sign in attempts.
         </p>
-        <p>
+        <p style="font-size: 15px">
           Click the button below to unlock your account.
         </p>
       </div>
-      <%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token), style: 'background-color: #4B7BE5; color: white; font-size: 15px; font-weight: bold; text-decoration: none; display: block; width: max-content; height: 20px; border: none; border-radius: 6px; padding: 12px 24px; margin: 48px auto 64px;' %>
+      <%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token), class: 'font-bold', style: 'background-color: #4B7BE5; color: white; font-size: 15px; text-decoration: none; display: block; width: max-content; height: 20px; border: none; border-radius: 6px; padding: 12px 24px; margin: 48px auto 64px;' %>
       <div style="background-color: #F6F8FA; height: 2px; margin: 24px auto"></div>
       <p style="color: #B5B5C3; font-size: 14px">
         © 2024 National Telehealth Technology Assessment Resource Center


### PR DESCRIPTION
## Covering the following changes:
- Bugs Fixed:
    - Emails for password resets, account unlocks, email confirmation, etc. were not styled

## Any other comments:
- These emails still lack images (e.g. a radar logo at the top) because it looks like Devise isn't currently set up in a way that allows us to easily add attachments to the automatic emails