### PR TITLE
Fix Data Usage & Scheduling checkbox label associations

### DIFF
--- a/server/app/views/client_data_usage_and_scheduling/_manage_pod_data_cap_modal.html.erb
+++ b/server/app/views/client_data_usage_and_scheduling/_manage_pod_data_cap_modal.html.erb
@@ -9,12 +9,12 @@
           <input class="forms--checkbox"
                   type="checkbox"
                   role="switch"
-                  id="flexSwitchCheckDefault"
+                  id="data-cap-checkbox"
                   name="client[wants_to_have_data_cap]"
                   <%= client.data_cap_max_usage.present? ? "checked" : nil %>
                   data-action="input->client-data-cap-form#onSwitchChange"
             />
-          <label class="form-check-label regular-text" for="flexSwitchCheckDefault">Use a data cap on this Pod</label>
+          <label class="form-check-label regular-text" for="data-cap-checkbox">Use a data cap on this Pod</label>
         </div>
       </div>
       <div class="forms--row  <%= client.data_cap_max_usage.nil? ? 'form-custom-opaque' : '' %>"

--- a/server/app/views/client_data_usage_and_scheduling/_manage_pod_scheduling_modal.html.erb
+++ b/server/app/views/client_data_usage_and_scheduling/_manage_pod_scheduling_modal.html.erb
@@ -9,12 +9,12 @@
             <input class="forms--checkbox"
                     type="checkbox"
                     role="switch"
-                    id="flexSwitchCheckDefault"
+                    id="custom-scheduling-checkbox"
                     name="client[custom_scheduling]"
                     <%= client.custom_scheduling ? "checked" : nil %>
                     data-action="input->client-scheduling-form#onSwitchChange"
               />
-            <label class="form-check-label regular-text" for="flexSwitchCheckDefault">Use a custom scheduling on this Pod</label>
+            <label class="form-check-label regular-text" for="custom-scheduling-checkbox">Use a custom scheduling on this Pod</label>
           </div>
         </div>
         <div class="forms--row">


### PR DESCRIPTION
## Covering the following changes:
- Bugs Fixed:
    - Clicking the "use a custom scheduling" label on the pod Data Usage & Scheduling page did not check/uncheck the checkbox
