### PR TITLE
Fix error on User Settings page when user has no accounts

### DIFF
--- a/server/app/controllers/users/registrations_controller.rb
+++ b/server/app/controllers/users/registrations_controller.rb
@@ -306,7 +306,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def set_auth_holder
-    is_account_accessible_through_share = current_user.shared_accounts.where(id: current_account.id).exists?
+    is_account_accessible_through_share = !current_account.nil? && current_user.shared_accounts.where(id: current_account.id).exists?
     is_all_accounts = current_account&.is_all_accounts? || false
     @auth_holder = AuthenticationHolder.new(current_user, is_all_accounts, is_account_accessible_through_share, is_super_user_disabled?) unless @auth_holder
     @auth_holder.set_account(current_account)

--- a/server/app/views/devise/registrations/edit.html.erb
+++ b/server/app/views/devise/registrations/edit.html.erb
@@ -15,7 +15,7 @@
 <div class="post fs-6 d-flex flex-column-fluid justify-content-center" id="kt_post">
   <!--begin::Container-->
   <div class="clients--details-container">
-    <% unless current_account.is_all_accounts? || !FeatureFlagHelper.is_available('notification_settings', current_user) %>
+    <% unless current_account.nil? || current_account.is_all_accounts? || !FeatureFlagHelper.is_available('notification_settings', current_user) %>
       <%= render partial: "application/components/tabs/page_tabs",
                  locals: {
                    tabs: [


### PR DESCRIPTION
## Covering the following changes:
- Bugs Fixed:
    - User Settings page would throw an error if the user had no accounts
