### PR TITLE
Update marketing site page titles & descriptions

### DIFF
--- a/toolkit_website/pages/404.tsx
+++ b/toolkit_website/pages/404.tsx
@@ -11,8 +11,8 @@ const NotFound = (): ReactElement => {
     <ViewportContextProvider>
       <>
         <Head>
-          <title>Radar - Page not found</title>
-          <meta name="description" content="Radar helps identify where Internet investment will go the furthest by providing insights into broadband as it is today in your community."/>
+          <title>Radar: Page not found</title>
+          <meta name="description" content="Radar is a community toolkit to test Internet speed, monitor and analyze broadband and get insights into where internet investments should be made."/>
         </Head>
         <Frame isDifferentColorFooter>
           <div style={styles.NotFoundPage}>

--- a/toolkit_website/pages/broadband-testing.tsx
+++ b/toolkit_website/pages/broadband-testing.tsx
@@ -14,8 +14,8 @@ const BroadbandTesting = (): ReactElement => {
     <ViewportContextProvider>
       <>
         <Head>
-          <title>Radar - Broadband Speed Testing for Consumers and Communities</title>
-          <meta name="description" content="Find out which areas have the most broadband needs through detailed Internet speed tests and mapping solutions."/>
+          <title>Radar: Internet Speed Test for Communities</title>
+          <meta name="description" content="Test your community's broadband using our Internet speed test tool to determine where investments will be most impactful."/>
         </Head>
         <Frame isDifferentColorFooter>
           <div style={styles.BroadbandTestingPage}>

--- a/toolkit_website/pages/get-started.tsx
+++ b/toolkit_website/pages/get-started.tsx
@@ -17,7 +17,7 @@ const GetStarted = (): ReactElement => {
     <ViewportContextProvider>
       <>
         <Head>
-          <title>Radar - Get Started with Radar Toolkit</title>
+          <title>Radar: Get Started with Radar Toolkit</title>
           <meta name={'description'} content={'Start using our broadband monitoring and speed testing tools in no time.'}/>
         </Head>
         <Frame isDifferentColorFooter

--- a/toolkit_website/pages/index.tsx
+++ b/toolkit_website/pages/index.tsx
@@ -13,8 +13,8 @@ const Index = (): ReactElement => {
     <ViewportContextProvider>
       <>
         <Head>
-          <title>Radar - Internet Speed Test and Monitoring for Better Broadband Investments</title>
-          <meta name="description" content="Radar helps identify where Internet investment will go the furthest by providing insights into broadband as it is today in your community."/>
+          <title>Radar: Internet Speed Test & Broadband Monitoring Tools</title>
+          <meta name="description" content="Radar is a community toolkit to test Internet speed, monitor and analyze broadband and get insights into where internet investments should be made."/>
         </Head>
         <Frame smallFooterMarginTop={'0px'}>
           <div style={styles.HomePage}>

--- a/toolkit_website/pages/mobile-testing.tsx
+++ b/toolkit_website/pages/mobile-testing.tsx
@@ -13,8 +13,8 @@ const MobileTesting = (): ReactElement => {
     <ViewportContextProvider>
       <>
         <Head>
-          <title>Radar - Broadband Speed Test for Mobile Devices</title>
-          <meta name="description" content="Test your wifi or cellular connection to find out if you're getting what you expect from your Internet provider."/>
+          <title>Radar: Mobile App to Test Wifi and Cellular Quality</title>
+          <meta name="description" content="Monitor the quality of wifi and cellular signal. Gain a deeper understanding of where internet is not available in your community quickly."/>
         </Head>
         <Frame isDifferentColorFooter >
           <div style={styles.MobilePage}>

--- a/toolkit_website/pages/site-monitoring.tsx
+++ b/toolkit_website/pages/site-monitoring.tsx
@@ -14,8 +14,8 @@ const SiteMonitoringPage = (): ReactElement => {
     <ViewportContextProvider>
       <>
         <Head>
-          <title>Radar - Remote Monitoring of your Sites' Internet Connectivity</title>
-          <meta name="description" content="Ensure sites' Internet connectivity quality matches your expectations through continuous remote monitoring."/>
+          <title>Radar: Broadband Monitoring Tools</title>
+          <meta name="description" content="Use our broadband remote monitoring solutions to continuously identify connectivity issues in your community."/>
         </Head>
         <Frame isDifferentColorFooter>
           <div style={styles.SiteMonitoringPage}>


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC-1946: Edit marketing site titles + metadata descriptions](https://linear.app/exactly/issue/TTAC-1946/edit-marketing-site-titles-metadata-descriptions)

Completes TTAC-1946.

## Covering the following changes:
- Other:
    - Update marketing side page titles and `<meta>` descriptions