### PR TITLE
Fix for import categories in network creation embedded component

### DIFF
--- a/server/app/controllers/location_categories_controller.rb
+++ b/server/app/controllers/location_categories_controller.rb
@@ -49,6 +49,7 @@ class LocationCategoriesController < ApplicationController
     @type = params[:type] || "create"
     @network_id = params[:network_id]
     @accounts = policy_scope(Account)
+    @pod_id = params[:pod_id]
     respond_to do |format|
       format.turbo_stream
     end

--- a/server/app/javascript/controllers/location_form_controller.js
+++ b/server/app/javascript/controllers/location_form_controller.js
@@ -30,7 +30,7 @@ export default class extends Controller {
 
   connect() {
     this.address = this.addressTarget.value;
-    this.isCreation = this.element.querySelector("input[name='location[id]']").value === "";
+    this.isCreation = this.element.querySelector("input[name='id']")?.value === "" || false;
     this.isManuallySetting = this.manualLatLongTarget.checked;
     this.token = document.querySelector('meta[name="csrf-token"]').content;
     if (this.isCreation) {

--- a/server/app/views/clients/edit_client/_edit_client_step_0.html.erb
+++ b/server/app/views/clients/edit_client/_edit_client_step_0.html.erb
@@ -63,7 +63,7 @@
 
       <span class="additional-text mt-1 wrap" data-pod-account-and-network-target="networkSubtitle">Assign your pods to a network to keep them organized.</span>
       <%= render partial: "pods/components/pod_creation_network_select" %>
-      <%= render partial: "pods/components/pod_network_creator_component", locals: { starts_invisible: true, form: form } %>
+      <%= render partial: "pods/components/pod_network_creator_component", locals: { starts_invisible: true, form: form, pod_id: @client.unix_user } %>
     </div>
 
     <% if current_user.super_user && !is_super_user_disabled? %>

--- a/server/app/views/location_categories/_import_from_another_account_modal.html.erb
+++ b/server/app/views/location_categories/_import_from_another_account_modal.html.erb
@@ -1,5 +1,8 @@
 <% back_url = @network_id.nil? ? new_location_url : edit_location_url(id: @network_id) %>
+<% back_url = edit_client_url(@pod_id) if @pod_id.present? %>
+
 <% turbo_frame = @network_id.nil? ? "new_location_modal" : "edit_location_modal" %>
+<% turbo_frame = "edit_client_modal" if @pod_id %>
 <div class="modal-header modals--header">
   <%= link_to back_url, { class: "tables--row-option table-menu-option", data_turbo_frame: turbo_frame, data_action: "click->custom-modal#closeModal", id: "manage-categories-button-ref" } do %>
     <%= image_tag image_url('arrow-left-dark.png'), width: 24, height: 24, class: "hoverable" %>

--- a/server/app/views/location_categories/import_from_another_account.turbo_stream.erb
+++ b/server/app/views/location_categories/import_from_another_account.turbo_stream.erb
@@ -1,4 +1,17 @@
-<% if @type == 'create' %>
+<% if @pod_id %>
+  <%= turbo_stream.update "edit_client_modal" do %>
+    <%= render partial: "application/components/modals/empty_custom_modal",
+               locals: {
+                 modal_title: 'Import Categories',
+                 modal_partial_path: "location_categories/import_from_another_account_modal",
+                 resource: @accounts,
+                 custom_submit_end_handler: nil,
+                 needs_overflow: true,
+                 pod_id: @pod_id
+               }
+    %>
+  <% end %>
+<% elsif @type == 'create' %>
   <%= turbo_stream.update "new_location_modal" do %>
     <%= render partial: "application/components/modals/empty_custom_modal",
                locals: {

--- a/server/app/views/networks/modals/shared/_network_details_modal.html.erb
+++ b/server/app/views/networks/modals/shared/_network_details_modal.html.erb
@@ -14,6 +14,7 @@
                         else
                           location.account.id
                         end %>
+<% pod_id = local_assigns[:pod_id] || nil %>
 
 <div class="modals--content-container <%= contained ? 'contained' : '' %>"
      data-type="full"
@@ -72,7 +73,7 @@
         </span>
     </div>
     <%= turbo_frame_tag "location-categories-dropdown" %>
-    <%= link_to "Import from another account…", categories_import_from_another_account_url(network_id: location&.id, type: type), data: { method: :get, turbo_stream: true }, class: "categories--import-button" %>
+    <%= link_to "Import from another account…", categories_import_from_another_account_url(network_id: location&.id, type: type, pod_id: pod_id), data: { method: :get, turbo_stream: true }, class: "categories--import-button" %>
   </div>
 
   <div class="modals--half-width-row mb-6">

--- a/server/app/views/pods/components/_pod_network_creator_component.html.erb
+++ b/server/app/views/pods/components/_pod_network_creator_component.html.erb
@@ -1,4 +1,5 @@
 <% invisible = local_assigns[:starts_invisible].present? ? local_assigns[:starts_invisible] : false %>
+<% pod_id = local_assigns[:pod_id] || nil %>
 
 <div class="pods--create-network-component-container <%= invisible ? 'invisible' : nil %>"
   data-pod-account-and-network-target="newNetworkComponent"
@@ -12,7 +13,8 @@
         footerless: true,
         contained: true,
         is_account_fixed: true,
-        location: Location.new
+        location: Location.new,
+        pod_id: pod_id
       }
   %>
 </div>


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC-2508: 🪳 BUG: Error when creating a new network from editing a pod](https://linear.app/exactly/issue/TTAC-2508/bug-error-when-creating-a-new-network-from-editing-a-pod)

Completes TTAC-2508.

## Covering the following changes:
- Bugs Fixed:
    - Fixed issue when trying to open the import categories modal within the create new network embedded component.