### PR TITLE
Fix missing ISP for Location in the UI

### DIFF
--- a/server/app/models/location.rb
+++ b/server/app/models/location.rb
@@ -286,7 +286,7 @@ include Recents
   end
 
   def autonomous_system
-    self.clients.map(&:autonomous_system).compact.first
+    self.clients.map(&:autonomous_system).compact.first || self.latest_measurement&.autonomous_system
   end
 
   private


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC-2877 - BUG: Location #73 is missing an ISP assingment](https://linear.app/exactly/issue/TTAC-2877/bug-location-73-is-missing-an-isp-assingment)

## Covering the following changes:
- Bugs Fixed:
    - Fixed an issue when a location without clients, but with measurements, wasn't showing the ISP.
