### PR TITLE
🚨 Sentry Alert: type 'Null' is not a subtype of type 'Map<String, dynamic>' in type cast

### DIFF
--- a/speedtest_mobile/network_connection_info/lib/network_connection_info_method_channel.dart
+++ b/speedtest_mobile/network_connection_info/lib/network_connection_info_method_channel.dart
@@ -17,8 +17,8 @@ class MethodChannelNetworkConnectionInfo extends NetworkConnectionInfoPlatform {
     final networkConnectionInfo =
         await methodChannel.invokeMethod<String>('getNetworkConnectionInfo');
     if (networkConnectionInfo != null) {
-      final jsonResponse = jsonDecode(networkConnectionInfo) as Map<String, dynamic>;
-      return ConnectionInfo.fromJson(jsonResponse);
+      final jsonResponse = jsonDecode(networkConnectionInfo) as Map<String, dynamic>?;
+      return jsonResponse != null ? ConnectionInfo.fromJson(jsonResponse) : null;
     } else {
       return null;
     }
@@ -29,8 +29,8 @@ class MethodChannelNetworkConnectionInfo extends NetworkConnectionInfoPlatform {
     final networkConnectionInfo =
         await methodChannel.invokeMethod<String>('getCellularNetworkConnectionInfo');
     if (networkConnectionInfo != null) {
-      final jsonResponse = jsonDecode(networkConnectionInfo) as Map<String, dynamic>;
-      return ConnectionInfo.fromJson(jsonResponse);
+      final jsonResponse = jsonDecode(networkConnectionInfo) as Map<String, dynamic>?;
+      return jsonResponse != null ? ConnectionInfo.fromJson(jsonResponse) : null;
     } else {
       return null;
     }


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC-2830: 🚨 Sentry Alert: type 'Null' is not a subtype of type 'Map<String, dynamic>' in type cast](https://linear.app/exactly/issue/TTAC-2830/sentry-alert-type-null-is-not-a-subtype-of-type-mapstring-dynamic-in)

Completes TTAC-2830

## Covering the following changes:
- Bugs Fixed:
    - consider Null value when decoding network info

## Any other comments:
- wasn't expecting the jsonDecode method tu return Null value.