### PR TITLE
Added quick check for lat/lng being present

### DIFF
--- a/server/app/controllers/client_api/v1/speed_tests_controller.rb
+++ b/server/app/controllers/client_api/v1/speed_tests_controller.rb
@@ -280,14 +280,11 @@ module ClientApi
           # of the tile, so it could be a miss. The zoom >= 6 is because at smaller
           # zoom levels, the tiles are so big that the chance of a miss is pretty low
           if zoom >= 6
-            REDIS.del("mvt_#{zoom}_#{x_y[0] - 1}_#{x_y[1]}")
-            REDIS.del("mvt_#{zoom}_#{x_y[0] + 1}_#{x_y[1]}")
-            REDIS.del("mvt_#{zoom}_#{x_y[0]}_#{x_y[1] - 1}")
-            REDIS.del("mvt_#{zoom}_#{x_y[0]}_#{x_y[1] + 1}")
-            REDIS.del("mvt_#{zoom}_#{x_y[0] - 1}_#{x_y[1] - 1}")
-            REDIS.del("mvt_#{zoom}_#{x_y[0] - 1}_#{x_y[1] + 1}")
-            REDIS.del("mvt_#{zoom}_#{x_y[0] + 1}_#{x_y[1] - 1}")
-            REDIS.del("mvt_#{zoom}_#{x_y[0] + 1}_#{x_y[1] + 1}")
+            x_range = (x_y[0] - 1..x_y[0] + 1).to_a
+            y_range = (x_y[1] - 1..x_y[1] + 1).to_a
+            x_range.product(y_range).each do |x, y|
+              REDIS.del("mvt_#{zoom}_#{x}_#{y}")
+            end
           end
         end
       end


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC-2997: Fix issue with tiling API failing when longitude is nil](https://linear.app/exactly/issue/TTAC-2997/fix-issue-with-tiling-api-failing-when-longitude-is-nil)

Completes TTAC-2997.

## Covering the following changes:
- Bugs Fixed:
    - Fixed calling cache invalidation logic even if test has no lat/lng