### PR TITLE
Quick fix for alert on pod missing account

### DIFF
--- a/server/app/views/application/components/tables/_generic_table.html.erb
+++ b/server/app/views/application/components/tables/_generic_table.html.erb
@@ -13,7 +13,7 @@
               row: row,
               type: type,
               widths: widths,
-              index: type == TablesHelper::TableTypes::NETWORK_PODS || type == TablesHelper::TableTypes::PODS ? row.unix_user : "#{row.id}-#{row.account.id}",
+              index: type == TablesHelper::TableTypes::NETWORK_PODS || type == TablesHelper::TableTypes::PODS ? row.unix_user : "#{row.id}-#{row.account&.id}",
               even: index.even?
             }
         %>


### PR DESCRIPTION
When a pod has no account, the generic table component was expecting the `.account` field to be always present, but in some workflows, it could not have it, so it was throwing an exception.

## This PR includes the following Linear tasks:
* [TTAC-3134: 🪳 BUG: Missing id from pod without an account initially](https://linear.app/exactly/issue/TTAC-3134/bug-missing-id-from-pod-without-an-account-initially)

Completes TTAC-3134.

## Covering the following changes:
- Bugs Fixed:
    - Pod measurement table throwing error if pod has no account attached.