### PR TITLE
Fix last pixel alerts thrown in dashboard charts

### DIFF
--- a/server/app/javascript/controllers/line_chart_controller.js
+++ b/server/app/javascript/controllers/line_chart_controller.js
@@ -44,7 +44,7 @@ export default class LineChartController extends ChartController {
     const shouldContinue = this.setupTooltipContext(mouseX, mouseY);
     if(!shouldContinue) return;
     const index = this.getIndexFromMouseX(mouseX);
-    if(index < 0 || index == null) return;
+    if(index < 0 || index == null || this.adjustedData[index] === undefined) return;
     const TOOLTIP_TITLE_BOTTOM_PADDING = 30;
     const TOOLTIP_TITLE_TOP_PADDING = 20;
     const TOOLTIP_DATA_TOP_PADDING = 53

--- a/server/app/javascript/controllers/multi_line_chart_controller.js
+++ b/server/app/javascript/controllers/multi_line_chart_controller.js
@@ -309,7 +309,10 @@ export default class MultiLineChartController extends ChartController {
 
   getXValueAtIndex(index) {
     const firstEntryValues = this.adjustedData.entries().next().value[1];
-    if(index === -1) return firstEntryValues[firstEntryValues.length - 1].x
+    if(index === -1 || firstEntryValues[index] === undefined) {
+      if(firstEntryValues.length >= 1) return firstEntryValues[firstEntryValues.length - 1].x;
+      else return 0;
+    }
     return firstEntryValues[index].x;
   }
 


### PR DESCRIPTION
## This PR includes the following Linear tasks:
* [TTAC-3049: Chart Tooltip is failing in the last pixel of the chart](https://linear.app/exactly/issue/TTAC-3049/chart-tooltip-is-failing-in-the-last-pixel-of-the-chart)

Completes TTAC-3049.

## Covering the following changes:
- Bugs Fixed:
    - Fixed alerts being thrown when hovering over the last pixel of the dashboard charts